### PR TITLE
react-stripe -> react-stripe-js

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@ Feature request or idea? Consider opening an
 [API review](https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md)!
 
 <!--
-.js is a thin wrapper around Stripe.js and Stripe
+React Stripe.js is a thin wrapper around Stripe.js and Stripe
 Elements for React. Please only file issues here that you believe
 represent bugs with React Stripe.js, not Stripe.js itself.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,10 @@
 Feature request or idea? Consider opening an
-[API review](https://github.com/stripe/react-stripe/tree/master/.github/API_REVIEW.md)!
+[API review](https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md)!
 
 <!--
-React Stripe is a thin wrapper around Stripe.js and Stripe
+.js is a thin wrapper around Stripe.js and Stripe
 Elements for React. Please only file issues here that you believe
-represent bugs with React Stripe, not Stripe.js itself.
+represent bugs with React Stripe.js, not Stripe.js itself.
 
 If you're having general trouble with Stripe.js or your Stripe integration,
 please reach out to us using the form at https://support.stripe.com/email or

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 Copy [this template] **or** link to an API review issue.
 
 [this template]:
-  https://github.com/stripe/react-stripe/tree/master/.github/API_REVIEW.md
+  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md
 
 ### Testing & documentation
 

--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -68,7 +68,7 @@ const addDemo = (directory, file, stories) => {
   stories.add(name, () => <ExampleComponent file={`${directory}/${file}`} />);
 };
 
-const hooksStories = storiesOf('react-stripe/Hooks', module);
+const hooksStories = storiesOf('react-stripe-js/Hooks', module);
 require
   .context('../examples/hooks/', false, /\/\d-(.*).js$/)
   .keys()
@@ -76,7 +76,7 @@ require
     addDemo('hooks', key.slice(2), hooksStories);
   });
 
-const classStories = storiesOf('react-stripe/Class Components', module);
+const classStories = storiesOf('react-stripe-js/Class Components', module);
 require
   .context('../examples/class-components/', false, /\/\d-(.*).js$/)
   .keys()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-React Stripe adheres to
+React Stripe.js adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v7.0.0-beta.0 2019-12-18

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,20 @@
-# Contributing to React Stripe
+# Contributing to React Stripe.js
 
-Thanks for contributing to React Stripe!
+Thanks for contributing to React Stripe.js!
 
 ## Issues
 
 React Stripe is a thin wrapper around [Stripe.js] and [Stripe
 Elements][elements] for React. Please only file issues here that you believe
-represent bugs with React Stripe, not Stripe.js itself.
+represent bugs with React Stripe.js, not Stripe.js itself.
 
 If you're having general trouble with Stripe.js or your Stripe integration,
 please reach out to us using the form at <https://support.stripe.com/email> or
 come chat with us at #stripe on freenode. We're very proud of our level of
 service, and we're more than happy to help you out with your integration.
 
-If you've found a bug in React Stripe, please [let us know][issue]! You may also
-want to check out our [issue template][issue-template].
+If you've found a bug in React Stripe.js, please [let us know][issue]! You may
+also want to check out our [issue template][issue-template].
 
 ## API review
 
@@ -68,5 +68,5 @@ passing any of these checks will cause the CI build to fail.
 [api-review]: .github/API_REVIEW.md
 [stripe.js]: https://stripe.com/docs/stripe.js
 [elements]: https://stripe.com/elements
-[issue]: https://github.com/stripe/react-stripe/issues/new
+[issue]: https://github.com/stripe/react-stripe-js/issues/new
 [issue-template]: .github/ISSUE_TEMPLATE.md

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # React Stripe.js
 
-React Stripe.js is a thin React wrapper around
-[Stripe Elements](https://stripe.com/docs/elements). It allows you to add
-Elements to any React app.
+React components for [Stripe.js](https://stripe.com/docs/stripe-js) and 
+[Stripe Elements](https://stripe.com/docs/elements).
 
 [![build status](https://img.shields.io/travis/stripe/react-stripe-js/master.svg?style=flat-square)](https://travis-ci.org/stripe/react-stripe-js)
 [![npm version](https://img.shields.io/npm/v/@stripe/react-stripe-js.svg?style=flat-square)](https://www.npmjs.com/package/@stripe/react-stripe-js)

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-# React Stripe
+# React Stripe.js
 
-React Stripe is a thin React wrapper around
+React Stripe.js is a thin React wrapper around
 [Stripe Elements](https://stripe.com/docs/elements). It allows you to add
 Elements to any React app.
 
-[![build status](https://img.shields.io/travis/stripe/react-stripe/master.svg?style=flat-square)](https://travis-ci.org/stripe/react-stripe)
-[![npm version](https://img.shields.io/npm/v/@stripe/react-stripe.svg?style=flat-square)](https://www.npmjs.com/package/@stripe/react-stripe)
+[![build status](https://img.shields.io/travis/stripe/react-stripe-js/master.svg?style=flat-square)](https://travis-ci.org/stripe/react-stripe-js)
+[![npm version](https://img.shields.io/npm/v/@stripe/react-stripe-js.svg?style=flat-square)](https://www.npmjs.com/package/@stripe/react-stripe-js)
 
 ## Getting Started
 
-- [Add React Stripe to your React app](https://stripe.com/docs/stripe-js/react-stripe#setup)
+- [Add React Stripe.js to your React app](https://stripe.com/docs/stripe-js/react#setup)
 - [Try it out using CodeSandbox](https://codesandbox.io/s/react-stripe-official-q1loc?fontsize=14&hidenavigation=1&theme=dark)
 
 ## Documentation
 
-- [React Stripe Docs](https://stripe.com/docs/stripe-js/react-stripe)
+- [React Stripe.js Docs](https://stripe.com/docs/stripe-js/react)
 - [Migrate from `react-stripe-elements`](docs/migrating.md)
 - [Legacy `react-stripe-elements` docs](https://github.com/stripe/react-stripe-elements/#react-stripe-elements)
 - [Examples](examples)
 
 ### Minimum Requirements
 
-React Stripe depends on the
+React Stripe.js depends on the
 [React Hooks API](https://reactjs.org/docs/hooks-intro.html). The minimum
 supported version of React is v16.8. If you use an older version, upgrade React
 to use this library. If you prefer not to upgrade your React version, we
@@ -30,5 +30,5 @@ recommend using legacy
 
 ### Contributing
 
-If you would like to contribute to React Stripe, please make sure to read our
+If you would like to contribute to React Stripe.js, please make sure to read our
 [contributor guidelines](CONTRIBUTING.md).

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -2,16 +2,16 @@
 
 This guide will walk you through migrating your Stripe integration from
 [`react-stripe-elements`](https://github.com/stripe/react-stripe-elements) to
-React Stripe.
+React Stripe.js.
 
 - Prefer something a little more comprehensive? Check out the official
-  [React Stripe docs](https://stripe.com/docs/stripe-js/react-stripe).
+  [React Stripe.js docs](https://stripe.com/docs/stripe-js/react).
 - Or take a look at some
-  [example integrations](https://github.com/stripe/react-stripe/tree/master/examples).
+  [example integrations](https://github.com/stripe/react-stripe-js/tree/master/examples).
 
 ### Prerequisites
 
-React Stripe depends on the
+React Stripe.js depends on the
 [React Hooks API](https://reactjs.org/docs/hooks-intro.html). The minimum
 supported version of React is v16.8. If you use an older version, upgrade React
 to use this library. If you prefer not to upgrade your React version, feel free
@@ -23,16 +23,16 @@ to continue using legacy
 ## 1. Install and fix imports
 
 First, use `npm` or `yarn` to remove `react-stripe-elements` and install
-`@stripe/react-stripe`.
+`@stripe/react-stripe-js`.
 
 ```sh
 npm uninstall react-stripe-elements
-npm install @stripe/react-stripe
+npm install @stripe/react-stripe-js
 ```
 
-After installing React Stripe, update your import statements. In places where
+After installing React Stripe.js, update your import statements. In places where
 you used to import from `react-stripe-elements`, adjust your code to import from
-`@stripe/react-stripe`.
+`@stripe/react-stripe-js`.
 
 #### Before
 
@@ -43,14 +43,14 @@ import {CardElement} from 'react-stripe-elements';
 #### After
 
 ```js
-import {CardElement} from '@stripe/react-stripe';
+import {CardElement} from '@stripe/react-stripe-js';
 ```
 
 <br />
 
 ## 2. Remove `<StripeProvider>`
 
-React Stripe no longer has a `<StripeProvider>` component. Instead you will
+React Stripe.js no longer has a `<StripeProvider>` component. Instead you will
 instantiate the [Stripe object](https://stripe.com/docs/js/initializing)
 yourself and pass it directly to `<Elements>`. We've prefilled the examples
 below with a sample test [API key](https://stripe.com/docs/keys). Replace it
@@ -74,7 +74,7 @@ const App = () => (
 #### After
 
 ```jsx
-import {Elements} from 'react-stripe-elements';
+import {Elements} from '@stripe/react-stripe-js';
 
 // Create the Stripe object yourself...
 const stripe = window.Stripe('pk_test_TYooMQauvdEDq54NiTphI7jx');
@@ -91,7 +91,7 @@ const App = () => (
 
 The way you pass in
 [Element options](https://stripe.com/docs/js/elements_object/create_element?type=card#elements_create-options)
-is different in React Stripe.
+is different in React Stripe.js.
 
 #### Before
 
@@ -120,7 +120,7 @@ import {CardElement} from 'react-stripe-elements';
 #### After
 
 ```jsx
-import {CardElement} from '@stripe/react-stripe';
+import {CardElement} from '@stripe/react-stripe-js';
 
 
 <CardElement
@@ -148,7 +148,7 @@ import {CardElement} from '@stripe/react-stripe';
 
 ## 3. `useStripe` and `useElements` instead of `injectStripe`.
 
-React Stripe uses hooks and consumers rather than higher order components.
+React Stripe.js uses hooks and consumers rather than higher order components.
 
 #### Before
 
@@ -168,7 +168,7 @@ const InjectedCheckoutForm = injectStripe(CheckoutForm);
 #### After
 
 ```jsx
-import {useStripe, useElements} from '@stripe/react-stripe';
+import {useStripe, useElements} from '@stripe/react-stripe-js';
 
 const CheckoutForm = (props) => {
   // Get a reference to Stripe or Elements using hooks.
@@ -180,7 +180,7 @@ const CheckoutForm = (props) => {
 
 // Or use `<ElementsConsumer>` if you do not want to use hooks.
 
-import {ElementsConsumer} from '@stripe/react-stripe';
+import {ElementsConsumer} from '@stripe/react-stripe-js';
 
 const CheckoutForm = (props) => {
   const {stripe, elements} = props;
@@ -201,7 +201,7 @@ const InjectedCheckoutForm = () => (
 
 ## 4. Pass in the Element instance to other Stripe.js methods.
 
-React Stripe does not have the automatic Element detection.
+React Stripe.js does not have the automatic Element detection.
 
 #### Before
 
@@ -233,7 +233,7 @@ const InjectedCheckoutForm = injectStripe(CheckoutForm);
 #### After
 
 ```jsx
-import {useStripe, useElements, CardElement} from 'react-stripe-elements';
+import {useStripe, useElements, CardElement} from '@stripe/react-stripe-js';
 
 const CheckoutForm = (props) => {
   const stripe = useStripe();
@@ -264,5 +264,5 @@ const CheckoutForm = (props) => {
 
 ### More Information
 
-- [React Stripe Docs](https://stripe.com/docs/stripe-js/react-stripe)
-- [Examples](https://github.com/stripe/react-stripe/tree/master/examples)
+- [React Stripe.js Docs](https://stripe.com/docs/stripe-js/react)
+- [Examples](https://github.com/stripe/react-stripe-js/tree/master/examples)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stripe/react-stripe",
+  "name": "@stripe/react-stripe-js",
   "version": "7.0.0-beta.0",
   "description": "React components for Stripe.js and Stripe Elements",
   "main": "dist/react-stripe.js",
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/stripe/react-stripe.git"
+    "url": "https://github.com/stripe/react-stripe-js.git"
   },
   "files": [
     "dist",


### PR DESCRIPTION
### Summary & motivation
Rename from React Stripe to React Stripe.js