### PR TITLE
remove inlined PropTypes for cjs and es builds

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,10 +9,24 @@ import pkg from './package.json';
 export default [
   {
     input: 'src/index.js',
-    external: ['react'],
+    external: ['react', 'prop-types'],
     output: [
       {file: pkg.main, format: 'cjs'},
       {file: pkg.module, format: 'es'},
+    ],
+    plugins: [
+      resolve(),
+      babel({
+        exclude: 'node_modules/**',
+      }),
+      commonjs(),
+    ],
+  },
+  // UMD build with inline PropTypes
+  {
+    input: 'src/index.js',
+    external: ['react'],
+    output: [
       {
         name: 'ReactStripe',
         file: pkg.browser,
@@ -23,10 +37,10 @@ export default [
       },
     ],
     plugins: [
+      resolve(),
       babel({
         exclude: 'node_modules/**',
       }),
-      resolve(),
       commonjs(),
     ],
   },
@@ -45,13 +59,13 @@ export default [
       },
     ],
     plugins: [
+      resolve(),
       babel({
         exclude: 'node_modules/**',
       }),
       replace({
         'process.env.NODE_ENV': JSON.stringify('production'),
       }),
-      resolve(),
       commonjs(),
       terser(),
     ],


### PR DESCRIPTION
### Summary & motivation
Fixes #11 

Rollup was inlining rather than requiring/importing PropTypes in the cjs and es builds.

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation
I inspected and used the build output.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
