### PR TITLE
fix minimal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const MyCheckoutForm = () => {
   const elements = useElements();
 
   const handleSubmit = async (event) => {
-    ev.preventDefault();
+    event.preventDefault();
     const {error, paymentMethod} = await stripe.createPaymentMethod({
       type: 'card',
       card: elements.getElement(CardElement),
@@ -48,7 +48,7 @@ const MyCheckoutForm = () => {
   return (
     <form onSubmit={handleSubmit}>
       <CardElement />
-      <button>Pay</button>
+      <button type="submit">Pay</button>
     </form>
   );
 };


### PR DESCRIPTION
Minor update to the minimal example, the event is called `event` and the button should have a type on it to be valid HTML and stop most linters from yelling at you.