### PR TITLE
Render a shell Element component on the server

### DIFF
--- a/src/components/createElementComponent.js
+++ b/src/components/createElementComponent.js
@@ -1,5 +1,5 @@
 // @flow
-/* eslint-disable react/forbid-prop-types */
+/* eslint-disable react/forbid-prop-types, react/no-unused-prop-types */
 import React, {useRef, useEffect, useLayoutEffect} from 'react';
 import PropTypes from 'prop-types';
 import {useElementsContextWithUseCase} from './Elements';
@@ -42,10 +42,10 @@ const useCallbackReference = (cb: MixedFunction) => {
   };
 };
 
-const createElementComponent = (type: string) => {
+const createElementComponent = (type: string, isServer: boolean) => {
   const displayName = `${capitalized(type)}Element`;
 
-  const Element = (props: Props) => {
+  const ClientElement = (props: Props) => {
     const {
       id,
       className,
@@ -121,6 +121,16 @@ const createElementComponent = (type: string) => {
 
     return <div id={id} className={className} ref={domNode} />;
   };
+
+  // Only render the Element wrapper in a server environment.
+  const ServerElement = (props: Props) => {
+    // Validate that we are in the right context by calling useElementsContextWithUseCase.
+    useElementsContextWithUseCase(`mounts <${displayName}>`);
+    const {id, className} = props;
+    return <div id={id} className={className} />;
+  };
+
+  const Element = isServer ? ServerElement : ClientElement;
 
   Element.propTypes = {
     id: PropTypes.string,

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,16 @@ import {
 } from './components/Elements';
 
 export {Elements, useElements, useStripe, ElementsConsumer};
-export const CardElement = createElementComponent('card');
-export const CardNumberElement = createElementComponent('cardNumber');
-export const CardExpiryElement = createElementComponent('cardExpiry');
-export const CardCvcElement = createElementComponent('cardCvc');
-export const IbanElement = createElementComponent('iban');
-export const IdealBankElement = createElementComponent('idealBank');
+
+const isServer = typeof window === 'undefined';
+
+export const CardElement = createElementComponent('card', isServer);
+export const CardNumberElement = createElementComponent('cardNumber', isServer);
+export const CardExpiryElement = createElementComponent('cardExpiry', isServer);
+export const CardCvcElement = createElementComponent('cardCvc', isServer);
+export const IbanElement = createElementComponent('iban', isServer);
+export const IdealBankElement = createElementComponent('idealBank', isServer);
 export const PaymentRequestButtonElement = createElementComponent(
-  'paymentRequestButton'
+  'paymentRequestButton',
+  isServer
 );


### PR DESCRIPTION
### Summary & motivation
Update `createElementComponent` to create a shell component on the server.

The shell component does only the following:
* Ensure the Element component is being rendered inside an `Elements` provider.
* Render the Element's wrapper `div` with `className` and `id`.

Fixes #19 
<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation
I wrote unit tests and manually tested the fix with Next.js SSR.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
