### PR TITLE
[Docs] Fixed imports in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install @stripe/react-stripe-js @stripe/stripe-js
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {loadStripe} from '@stripe/react-stripe-js';
+import {loadStripe} from '@stripe/stripe-js';
 import {
   CardElement,
   Elements,
@@ -75,7 +75,7 @@ ReactDOM.render(<App />, document.body);
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {loadStripe} from '@stripe/react-stripe-js';
+import {loadStripe} from '@stripe/stripe-js';
 import {CardElement, Elements, ElementsConsumer} from '@stripe/react-stripe-js';
 
 class CheckoutForm extends React.Component {


### PR DESCRIPTION
### Summary & motivation

Imports were defined incorrectly in the examples in the README.md causing errors without easy debugging. Definitely a trap for young players! 

Almost raised a ticket but instead here is a fixed PR 😄 . 

### Testing & documentation

This is what I did to make it work in my app that uses the library 😆 .