### PR TITLE
Add comment about loadStripe outside of render in examples

### DIFF
--- a/examples/class-components/0-Card-Minimal.js
+++ b/examples/class-components/0-Card-Minimal.js
@@ -73,6 +73,8 @@ const InjectedCheckoutForm = () => {
   );
 };
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/class-components/1-Card-Detailed.js
+++ b/examples/class-components/1-Card-Detailed.js
@@ -248,6 +248,8 @@ const ELEMENTS_OPTIONS = {
   ],
 };
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/class-components/2-Split-Card.js
+++ b/examples/class-components/2-Split-Card.js
@@ -152,6 +152,8 @@ const InjectedCheckoutForm = () => (
   </ElementsConsumer>
 );
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/class-components/3-Payment-Request-Button.js
+++ b/examples/class-components/3-Payment-Request-Button.js
@@ -121,6 +121,8 @@ const InjectedCheckoutForm = () => (
   </ElementsConsumer>
 );
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/class-components/4-IBAN.js
+++ b/examples/class-components/4-IBAN.js
@@ -123,6 +123,8 @@ const InjectedCheckoutForm = () => (
   </ElementsConsumer>
 );
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/class-components/5-iDEAL.js
+++ b/examples/class-components/5-iDEAL.js
@@ -115,6 +115,8 @@ const InjectedCheckoutForm = () => (
   </ElementsConsumer>
 );
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/hooks/0-Card-Minimal.js
+++ b/examples/hooks/0-Card-Minimal.js
@@ -63,6 +63,8 @@ const CheckoutForm = () => {
   );
 };
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/hooks/1-Card-Detailed.js
+++ b/examples/hooks/1-Card-Detailed.js
@@ -231,6 +231,8 @@ const ELEMENTS_OPTIONS = {
   ],
 };
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/hooks/2-Split-Card.js
+++ b/examples/hooks/2-Split-Card.js
@@ -129,6 +129,8 @@ const CheckoutForm = () => {
   );
 };
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/hooks/3-Payment-Request-Button.js
+++ b/examples/hooks/3-Payment-Request-Button.js
@@ -94,6 +94,8 @@ const CheckoutForm = () => {
   );
 };
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/hooks/4-IBAN.js
+++ b/examples/hooks/4-IBAN.js
@@ -104,6 +104,8 @@ const CheckoutForm = () => {
   );
 };
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {

--- a/examples/hooks/5-iDEAL.js
+++ b/examples/hooks/5-iDEAL.js
@@ -95,6 +95,8 @@ const CheckoutForm = () => {
   );
 };
 
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
 const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
 
 const App = () => {


### PR DESCRIPTION
### Summary & motivation

Add the following clarification comment to examples:
> Make sure to call `loadStripe` outside of a component’s render to avoid recreating the `Stripe` object on every render.
