### PR TITLE
Add displayName property to context object for easier debugging with React Devtools

### DIFF
--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -65,6 +65,7 @@ type ElementContext = {|
 |};
 
 const ElementsContext = React.createContext<?ElementContext>();
+ElementsContext.displayName = 'Stripe';
 
 export const parseElementsContext = (
   ctx: ?ElementContext,

--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -65,7 +65,7 @@ type ElementContext = {|
 |};
 
 const ElementsContext = React.createContext<?ElementContext>();
-ElementsContext.displayName = 'Stripe';
+ElementsContext.displayName = 'ElementsContext';
 
 export const parseElementsContext = (
   ctx: ?ElementContext,


### PR DESCRIPTION
### Summary & motivation
Simple change to make debugging with React DevTools a little bit easier by having a non-generic displayName. 

In the devtools window the context component currently shows up as `<Context.Provdier>` this change would make it show up as `<Stripe.Provider>` With the generic name it can be a little annoying debugging if you have multiple providers all with the same generic displayName. 

**before**
<img width="778" alt="Screen Shot 2020-02-04 at 10 02 10 AM" src="https://user-images.githubusercontent.com/4275720/73772931-fe174c80-4735-11ea-9f9c-0cfb1b6a7e1f.png">
**after**
<img width="778" alt="Screen Shot 2020-02-04 at 10 00 58 AM" src="https://user-images.githubusercontent.com/4275720/73772959-07a0b480-4736-11ea-92d4-259392cc2a8f.png">

If you're unfamiliar with the context displayName documentation is here: https://reactjs.org/docs/context.html#contextdisplayname

My real motivation for this is an issue with a project that has multiple generic named "Provider" components and I was tracking the following a warning down:
<img width="772" alt="Screen Shot 2020-02-04 at 10 15 56 AM" src="https://user-images.githubusercontent.com/4275720/73773836-c01b2800-4737-11ea-9b7f-bf8aa82ddd72.png">
After a little bit of digging realized it was related to `react-stripe-elements` as it has a context provider just named `<Provider>` So I just want to make this new iteration of stripe elements a little bit easier to debug.

### Testing & documentation

Use React DevTools to confirm that the correct displayName is present.


**Note for maintainers** I chose a generic displayName "Stripe" but will leave it up to you if you want a more descriptive name like StripeContext or StripeElementContext