### PR TITLE
Fix React named imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "lint": "eslint '{src,examples}/**/*.{ts,tsx,js}'",
     "lint:prettier": "prettier './**/*.js' './**/*.css' './**/*.md' --list-different",
     "typecheck": "tsc",
-    "build": "yarn run clean && yarn run rollup -c",
+    "build": "yarn run clean && yarn run rollup -c && yarn checkimport",
     "checkimport": "scripts/check-imports",
     "clean": "rimraf dist",
     "prettier:fix": "prettier './**/*.js' './**/*.css' './**/*.md' --write",
-    "ci": "yarn run lint && yarn run lint:prettier && yarn run test && yarn run typecheck && yarn run build && yarn run checkimport",
+    "ci": "yarn run lint && yarn run lint:prettier && yarn run test && yarn run typecheck && yarn run build",
     "prepublish": "yarn run ci",
     "doctoc": "doctoc README.md",
     "storybook": "start-storybook -p 6006 "

--- a/scripts/check-imports
+++ b/scripts/check-imports
@@ -2,8 +2,7 @@
 
 BASE_DIR="$(dirname "$0")/..";
 
-# Generated type definitions should not include default imports.
-function checkImport {
+checkImport() {
     file=$1
     regexp=$2
     message=$3

--- a/scripts/check-imports
+++ b/scripts/check-imports
@@ -1,22 +1,27 @@
 #!/bin/sh
 
-# Generated type definitions should not include default imports.
-
 BASE_DIR="$(dirname "$0")/..";
 
-OUTPUT_FILE="/dist/react-stripe.d.ts"
+# Generated type definitions should not include default imports.
+function checkImport {
+    file=$1
+    regexp=$2
+    message=$3
+    grep "${regexp}" "${BASE_DIR}${file}"
 
-grep 'import [^*{]' "${BASE_DIR}${OUTPUT_FILE}"
+    case $? in
+        1) true
+            ;; 
+        0) 
+            echo "Found disallowed import in ${file}"
+            echo "${message}"
+            false
+            ;;
+        *)
+            false
+            ;;
+    esac
+}
 
-case $? in
-    1) true
-        ;; 
-    0) 
-        echo "Found disallowed default import in ${OUTPUT_FILE}"
-        echo 'Please only use * or named imports for types'
-        false
-        ;;
-    *)
-        false
-        ;;
-esac
+checkImport "/dist/react-stripe.d.ts" 'import [^*{]' 'Please only use * or named imports for types' && \
+checkImport "/dist/react-stripe.esm.js" 'import.*{' 'Please do not use named imports for dependencies'

--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -1,5 +1,5 @@
 // Must use `import *` or named imports for React's types
-import * as ReactType from 'react';
+import {FunctionComponent, ReactElement, ReactNode} from 'react';
 import * as stripeJs from '@stripe/stripe-js';
 
 import React from 'react';
@@ -86,7 +86,7 @@ interface ElementsProps {
 interface PrivateElementsProps {
   stripe: unknown;
   options?: stripeJs.StripeElementsOptions;
-  children?: ReactType.ReactNode;
+  children?: ReactNode;
 }
 
 /**
@@ -99,7 +99,7 @@ interface PrivateElementsProps {
  *
  * @docs https://stripe.com/docs/stripe-js/react#elements-provider
  */
-export const Elements: ReactType.FC<ElementsProps> = ({
+export const Elements: FunctionComponent<ElementsProps> = ({
   stripe: rawStripeProp,
   options,
   children,
@@ -194,19 +194,19 @@ export const useStripe = (): stripeJs.Stripe | null => {
 };
 
 interface ElementsConsumerProps {
-  children: (props: ElementsContextValue) => ReactType.ReactNode;
+  children: (props: ElementsContextValue) => ReactNode;
 }
 
 /**
  * @docs https://stripe.com/docs/stripe-js/react#elements-consumer
  */
-export const ElementsConsumer: ReactType.FC<ElementsConsumerProps> = ({
+export const ElementsConsumer: FunctionComponent<ElementsConsumerProps> = ({
   children,
 }) => {
   const ctx = useElementsContextWithUseCase('mounts <ElementsConsumer>');
 
   // Assert to satsify the busted React.FC return type (it should be ReactNode)
-  return children(ctx) as ReactType.ReactElement | null;
+  return children(ctx) as ReactElement | null;
 };
 
 ElementsConsumer.propTypes = {

--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -1,15 +1,8 @@
 // Must use `import *` or named imports for React's types
-import * as React from 'react';
+import * as ReactType from 'react';
 import * as stripeJs from '@stripe/stripe-js';
 
-import {
-  createContext,
-  useContext,
-  useMemo,
-  useState,
-  useEffect,
-  useRef,
-} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import {isEqual} from '../utils/isEqual';
@@ -57,7 +50,7 @@ interface ElementsContextValue {
   stripe: stripeJs.Stripe | null;
 }
 
-const ElementsContext = createContext<ElementsContextValue | null>(null);
+const ElementsContext = React.createContext<ElementsContextValue | null>(null);
 ElementsContext.displayName = 'ElementsContext';
 
 export const parseElementsContext = (
@@ -93,7 +86,7 @@ interface ElementsProps {
 interface PrivateElementsProps {
   stripe: unknown;
   options?: stripeJs.StripeElementsOptions;
-  children?: React.ReactNode;
+  children?: ReactType.ReactNode;
 }
 
 /**
@@ -106,15 +99,17 @@ interface PrivateElementsProps {
  *
  * @docs https://stripe.com/docs/stripe-js/react#elements-provider
  */
-export const Elements: React.FC<ElementsProps> = ({
+export const Elements: ReactType.FC<ElementsProps> = ({
   stripe: rawStripeProp,
   options,
   children,
 }: PrivateElementsProps) => {
-  const final = useRef(false);
-  const isMounted = useRef(true);
-  const parsed = useMemo(() => parseStripeProp(rawStripeProp), [rawStripeProp]);
-  const [ctx, setContext] = useState<ElementsContextValue>(() => ({
+  const final = React.useRef(false);
+  const isMounted = React.useRef(true);
+  const parsed = React.useMemo(() => parseStripeProp(rawStripeProp), [
+    rawStripeProp,
+  ]);
+  const [ctx, setContext] = React.useState<ElementsContextValue>(() => ({
     stripe: null,
     elements: null,
   }));
@@ -159,7 +154,7 @@ export const Elements: React.FC<ElementsProps> = ({
     }
   }
 
-  useEffect(() => {
+  React.useEffect(() => {
     return (): void => {
       isMounted.current = false;
     };
@@ -178,7 +173,7 @@ Elements.propTypes = {
 export const useElementsContextWithUseCase = (
   useCaseMessage: string
 ): ElementsContextValue => {
-  const ctx = useContext(ElementsContext);
+  const ctx = React.useContext(ElementsContext);
   return parseElementsContext(ctx, useCaseMessage);
 };
 
@@ -199,19 +194,19 @@ export const useStripe = (): stripeJs.Stripe | null => {
 };
 
 interface ElementsConsumerProps {
-  children: (props: ElementsContextValue) => React.ReactNode;
+  children: (props: ElementsContextValue) => ReactType.ReactNode;
 }
 
 /**
  * @docs https://stripe.com/docs/stripe-js/react#elements-consumer
  */
-export const ElementsConsumer: React.FC<ElementsConsumerProps> = ({
+export const ElementsConsumer: ReactType.FC<ElementsConsumerProps> = ({
   children,
 }) => {
   const ctx = useElementsContextWithUseCase('mounts <ElementsConsumer>');
 
   // Assert to satsify the busted React.FC return type (it should be ReactNode)
-  return children(ctx) as React.ReactElement | null;
+  return children(ctx) as ReactType.ReactElement | null;
 };
 
 ElementsConsumer.propTypes = {

--- a/src/components/createElementComponent.test.js
+++ b/src/components/createElementComponent.test.js
@@ -1,14 +1,8 @@
-import React, {useLayoutEffect} from 'react';
+import React from 'react';
 import {mount} from 'enzyme';
 import {Elements} from './Elements';
 import createElementComponent from './createElementComponent';
 import {mockElements, mockElement, mockStripe} from '../../test/mocks';
-
-jest.mock('react', () => {
-  const actual = jest.requireActual('react');
-  jest.spyOn(actual, 'useLayoutEffect');
-  return actual;
-});
 
 describe('createElementComponent', () => {
   let stripe;
@@ -27,7 +21,7 @@ describe('createElementComponent', () => {
     element = mockElement();
     stripe.elements.mockReturnValue(elements);
     elements.create.mockReturnValue(element);
-    useLayoutEffect.mockClear();
+    jest.spyOn(React, 'useLayoutEffect');
     element.on = jest.fn((event, fn) => {
       switch (event) {
         case 'change':
@@ -97,7 +91,7 @@ describe('createElementComponent', () => {
         </Elements>
       );
 
-      expect(useLayoutEffect).not.toHaveBeenCalled();
+      expect(React.useLayoutEffect).not.toHaveBeenCalled();
     });
   });
 
@@ -151,6 +145,8 @@ describe('createElementComponent', () => {
       expect(element.mount).toHaveBeenCalledWith(
         wrapper.find('div').getDOMNode()
       );
+
+      expect(React.useLayoutEffect).toHaveBeenCalled();
     });
 
     it('does not create and mount until Elements has been instantiated', () => {

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -1,5 +1,5 @@
 // Must use `import *` or named imports for React's types
-import * as ReactType from 'react';
+import {FunctionComponent} from 'react';
 import * as stripeJs from '@stripe/stripe-js';
 
 import React from 'react';
@@ -43,10 +43,10 @@ const capitalized = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 const createElementComponent = (
   type: stripeJs.StripeElementType,
   isServer: boolean
-): ReactType.FC<ElementProps> => {
+): FunctionComponent<ElementProps> => {
   const displayName = `${capitalized(type)}Element`;
 
-  const ClientElement: ReactType.FC<PrivateElementProps> = ({
+  const ClientElement: FunctionComponent<PrivateElementProps> = ({
     id,
     className,
     options = {},
@@ -123,7 +123,7 @@ const createElementComponent = (
   };
 
   // Only render the Element wrapper in a server environment.
-  const ServerElement: ReactType.FC<PrivateElementProps> = (props) => {
+  const ServerElement: FunctionComponent<PrivateElementProps> = (props) => {
     // Validate that we are in the right context by calling useElementsContextWithUseCase.
     useElementsContextWithUseCase(`mounts <${displayName}>`);
     const {id, className} = props;
@@ -146,7 +146,7 @@ const createElementComponent = (
   Element.displayName = displayName;
   (Element as any).__elementType = type;
 
-  return Element as ReactType.FC<ElementProps>;
+  return Element as FunctionComponent<ElementProps>;
 };
 
 export default createElementComponent;

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -1,8 +1,9 @@
 // Must use `import *` or named imports for React's types
-import * as React from 'react';
+import * as ReactType from 'react';
 import * as stripeJs from '@stripe/stripe-js';
 
-import {useRef, useEffect, useLayoutEffect} from 'react';
+import React from 'react';
+
 import PropTypes from 'prop-types';
 
 import {useElementsContextWithUseCase} from './Elements';
@@ -42,10 +43,10 @@ const capitalized = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 const createElementComponent = (
   type: stripeJs.StripeElementType,
   isServer: boolean
-): React.FC<ElementProps> => {
+): ReactType.FC<ElementProps> => {
   const displayName = `${capitalized(type)}Element`;
 
-  const ClientElement: React.FC<PrivateElementProps> = ({
+  const ClientElement: ReactType.FC<PrivateElementProps> = ({
     id,
     className,
     options = {},
@@ -56,8 +57,8 @@ const createElementComponent = (
     onClick = noop,
   }) => {
     const {elements} = useElementsContextWithUseCase(`mounts <${displayName}>`);
-    const elementRef = useRef<stripeJs.StripeElement | null>(null);
-    const domNode = useRef<HTMLDivElement | null>(null);
+    const elementRef = React.useRef<stripeJs.StripeElement | null>(null);
+    const domNode = React.useRef<HTMLDivElement | null>(null);
 
     const callOnReady = useCallbackReference(onReady);
     const callOnBlur = useCallbackReference(onBlur);
@@ -65,7 +66,7 @@ const createElementComponent = (
     const callOnClick = useCallbackReference(onClick);
     const callOnChange = useCallbackReference(onChange);
 
-    useLayoutEffect(() => {
+    React.useLayoutEffect(() => {
       if (elementRef.current == null && elements && domNode.current != null) {
         const element = elements.create(type as any, options);
         elementRef.current = element;
@@ -82,8 +83,8 @@ const createElementComponent = (
       }
     });
 
-    const prevOptions = useRef(options);
-    useEffect(() => {
+    const prevOptions = React.useRef(options);
+    React.useEffect(() => {
       if (
         prevOptions.current &&
         prevOptions.current.paymentRequest !== options.paymentRequest
@@ -109,7 +110,7 @@ const createElementComponent = (
       }
     }, [options]);
 
-    useEffect(
+    React.useEffect(
       () => () => {
         if (elementRef.current) {
           elementRef.current.destroy();
@@ -122,7 +123,7 @@ const createElementComponent = (
   };
 
   // Only render the Element wrapper in a server environment.
-  const ServerElement: React.FC<PrivateElementProps> = (props) => {
+  const ServerElement: ReactType.FC<PrivateElementProps> = (props) => {
     // Validate that we are in the right context by calling useElementsContextWithUseCase.
     useElementsContextWithUseCase(`mounts <${displayName}>`);
     const {id, className} = props;
@@ -145,7 +146,7 @@ const createElementComponent = (
   Element.displayName = displayName;
   (Element as any).__elementType = type;
 
-  return Element as React.FC<ElementProps>;
+  return Element as ReactType.FC<ElementProps>;
 };
 
 export default createElementComponent;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import * as ReactType from 'react';
+import {FunctionComponent} from 'react';
 import * as stripeJs from '@stripe/stripe-js';
 
 export interface ElementProps {
@@ -42,7 +42,7 @@ export interface CardElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeCardElement) => any;
 }
 
-export type CardElementComponent = ReactType.FC<CardElementProps>;
+export type CardElementComponent = FunctionComponent<CardElementProps>;
 
 export interface CardNumberElementProps extends ElementProps {
   /**
@@ -63,7 +63,9 @@ export interface CardNumberElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeCardNumberElement) => any;
 }
 
-export type CardNumberElementComponent = ReactType.FC<CardNumberElementProps>;
+export type CardNumberElementComponent = FunctionComponent<
+  CardNumberElementProps
+>;
 
 export interface CardExpiryElementProps extends ElementProps {
   /**
@@ -84,7 +86,9 @@ export interface CardExpiryElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeCardExpiryElement) => any;
 }
 
-export type CardExpiryElementComponent = ReactType.FC<CardExpiryElementProps>;
+export type CardExpiryElementComponent = FunctionComponent<
+  CardExpiryElementProps
+>;
 
 export interface CardCvcElementProps extends ElementProps {
   /**
@@ -105,7 +109,7 @@ export interface CardCvcElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeCardCvcElement) => any;
 }
 
-export type CardCvcElementComponent = ReactType.FC<CardCvcElementProps>;
+export type CardCvcElementComponent = FunctionComponent<CardCvcElementProps>;
 
 export interface IbanElementProps extends ElementProps {
   /**
@@ -126,7 +130,7 @@ export interface IbanElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeIbanElement) => any;
 }
 
-export type IbanElementComponent = ReactType.FC<IbanElementProps>;
+export type IbanElementComponent = FunctionComponent<IbanElementProps>;
 
 export interface IdealBankElementProps extends ElementProps {
   /**
@@ -147,7 +151,9 @@ export interface IdealBankElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeIdealBankElement) => any;
 }
 
-export type IdealBankElementComponent = ReactType.FC<IdealBankElementProps>;
+export type IdealBankElementComponent = FunctionComponent<
+  IdealBankElementProps
+>;
 
 export interface PaymentRequestButtonElementProps extends ElementProps {
   /**
@@ -169,7 +175,7 @@ export interface PaymentRequestButtonElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripePaymentRequestButtonElement) => any;
 }
 
-export type PaymentRequestButtonElementComponent = ReactType.FC<
+export type PaymentRequestButtonElementComponent = FunctionComponent<
   PaymentRequestButtonElementProps
 >;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as ReactType from 'react';
 import * as stripeJs from '@stripe/stripe-js';
 
 export interface ElementProps {
@@ -42,7 +42,7 @@ export interface CardElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeCardElement) => any;
 }
 
-export type CardElementComponent = React.FC<CardElementProps>;
+export type CardElementComponent = ReactType.FC<CardElementProps>;
 
 export interface CardNumberElementProps extends ElementProps {
   /**
@@ -63,7 +63,7 @@ export interface CardNumberElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeCardNumberElement) => any;
 }
 
-export type CardNumberElementComponent = React.FC<CardNumberElementProps>;
+export type CardNumberElementComponent = ReactType.FC<CardNumberElementProps>;
 
 export interface CardExpiryElementProps extends ElementProps {
   /**
@@ -84,7 +84,7 @@ export interface CardExpiryElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeCardExpiryElement) => any;
 }
 
-export type CardExpiryElementComponent = React.FC<CardExpiryElementProps>;
+export type CardExpiryElementComponent = ReactType.FC<CardExpiryElementProps>;
 
 export interface CardCvcElementProps extends ElementProps {
   /**
@@ -105,7 +105,7 @@ export interface CardCvcElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeCardCvcElement) => any;
 }
 
-export type CardCvcElementComponent = React.FC<CardCvcElementProps>;
+export type CardCvcElementComponent = ReactType.FC<CardCvcElementProps>;
 
 export interface IbanElementProps extends ElementProps {
   /**
@@ -126,7 +126,7 @@ export interface IbanElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeIbanElement) => any;
 }
 
-export type IbanElementComponent = React.FC<IbanElementProps>;
+export type IbanElementComponent = ReactType.FC<IbanElementProps>;
 
 export interface IdealBankElementProps extends ElementProps {
   /**
@@ -147,7 +147,7 @@ export interface IdealBankElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripeIdealBankElement) => any;
 }
 
-export type IdealBankElementComponent = React.FC<IdealBankElementProps>;
+export type IdealBankElementComponent = ReactType.FC<IdealBankElementProps>;
 
 export interface PaymentRequestButtonElementProps extends ElementProps {
   /**
@@ -169,7 +169,7 @@ export interface PaymentRequestButtonElementProps extends ElementProps {
   onReady?: (element: stripeJs.StripePaymentRequestButtonElement) => any;
 }
 
-export type PaymentRequestButtonElementComponent = React.FC<
+export type PaymentRequestButtonElementComponent = ReactType.FC<
   PaymentRequestButtonElementProps
 >;
 

--- a/src/utils/useCallbackReference.ts
+++ b/src/utils/useCallbackReference.ts
@@ -1,11 +1,11 @@
-import {useRef, useEffect} from 'react';
+import React from 'react';
 
 export const useCallbackReference = <A extends unknown[]>(
   cb?: (...args: A) => any
 ): ((...args: A) => void) => {
-  const ref = useRef(cb);
+  const ref = React.useRef(cb);
 
-  useEffect(() => {
+  React.useEffect(() => {
     ref.current = cb;
   }, [cb]);
 

--- a/src/utils/usePrevious.test.tsx
+++ b/src/utils/usePrevious.test.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react';
+import * as ReactType from 'react';
+import React from 'react';
 import {mount} from 'enzyme';
 import {usePrevious} from './usePrevious';
 
-const TestComponent: React.FC<{foo: string}> = ({foo}) => {
+const TestComponent: ReactType.FC<{foo: string}> = ({foo}) => {
   const lastFoo = usePrevious(foo);
   return <div>{lastFoo}</div>;
 };

--- a/src/utils/usePrevious.test.tsx
+++ b/src/utils/usePrevious.test.tsx
@@ -1,9 +1,9 @@
-import * as ReactType from 'react';
+import {FunctionComponent} from 'react';
 import React from 'react';
 import {mount} from 'enzyme';
 import {usePrevious} from './usePrevious';
 
-const TestComponent: ReactType.FC<{foo: string}> = ({foo}) => {
+const TestComponent: FunctionComponent<{foo: string}> = ({foo}) => {
   const lastFoo = usePrevious(foo);
   return <div>{lastFoo}</div>;
 };

--- a/src/utils/usePrevious.ts
+++ b/src/utils/usePrevious.ts
@@ -1,9 +1,9 @@
-import {useRef, useEffect} from 'react';
+import React from 'react';
 
 export const usePrevious = <T>(value: T): T => {
-  const ref = useRef(value);
+  const ref = React.useRef(value);
 
-  useEffect(() => {
+  React.useEffect(() => {
     ref.current = value;
   }, [value]);
 


### PR DESCRIPTION
### Summary & motivation

Fixes #38 

Only use default import for `react`
Use react types through `ReactType`

### Testing & documentation

Added test to ensure no named imports are used for code (not types) since React and related are not ES Modules.
