### PR TITLE
Fpx bank and au bank account elements

### DIFF
--- a/examples/class-components/6-FPX.js
+++ b/examples/class-components/6-FPX.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import {loadStripe} from '@stripe/stripe-js';
+import {FpxBankElement, Elements, ElementsConsumer} from '../../src';
+
+import {logEvent, Result, ErrorResult} from '../util';
+import '../styles/common.css';
+
+const ELEMENT_OPTIONS = {
+  accountHolderType: 'individual',
+  classes: {
+    base: 'StripeElementFpx',
+    focus: 'StripeElementFpx--focus',
+  },
+  style: {
+    base: {
+      padding: '10px 14px',
+      fontSize: '18px',
+      color: '#424770',
+      letterSpacing: '0.025em',
+      '::placeholder': {
+        color: '#aab7c4',
+      },
+    },
+    invalid: {
+      color: '#9e2146',
+    },
+  },
+};
+
+class CheckoutForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {name: '', errorMessage: null, paymentMethod: null};
+  }
+
+  handleSubmit = async (event) => {
+    event.preventDefault();
+
+    const {stripe, elements} = this.props;
+    const {name} = this.state;
+
+    if (!stripe || !elements) {
+      // Stripe.js has not loaded yet. Make sure to disable
+      // form submission until Stripe.js has loaded.
+      return;
+    }
+
+    const fpxBankElement = elements.getElement(FpxBankElement);
+
+    const payload = await stripe.createPaymentMethod({
+      type: 'fpx',
+      fpx: fpxBankElement,
+      billing_details: {
+        name,
+      },
+    });
+
+    if (payload.error) {
+      console.log('[error]', payload.error);
+      this.setState({
+        errorMessage: payload.error.message,
+        paymentMethod: null,
+      });
+    } else {
+      console.log('[PaymentMethod]', payload.paymentMethod);
+      this.setState({
+        paymentMethod: payload.paymentMethod,
+        errorMessage: null,
+      });
+    }
+  };
+
+  render() {
+    const {errorMessage, paymentMethod, name} = this.state;
+    const {stripe} = this.props;
+    return (
+      <form onSubmit={this.handleSubmit}>
+        <label htmlFor="name">Full Name</label>
+        <input
+          id="name"
+          required
+          placeholder="Jenny Rosen"
+          value={name}
+          onChange={(event) => {
+            this.setState({name: event.target.value});
+          }}
+        />
+        <label htmlFor="fpx">iDEAL Bank</label>
+        <FpxBankElement
+          id="fpx"
+          onBlur={logEvent('blur')}
+          onChange={logEvent('change')}
+          onFocus={logEvent('focus')}
+          onReady={logEvent('ready')}
+          options={ELEMENT_OPTIONS}
+        />
+        {errorMessage && <ErrorResult>{errorMessage}</ErrorResult>}
+        {paymentMethod && (
+          <Result>Got PaymentMethod: {paymentMethod.id}</Result>
+        )}
+        <button type="submit" disabled={!stripe}>
+          Pay
+        </button>
+      </form>
+    );
+  }
+}
+
+const InjectedCheckoutForm = () => (
+  <ElementsConsumer>
+    {({stripe, elements}) => (
+      <CheckoutForm stripe={stripe} elements={elements} />
+    )}
+  </ElementsConsumer>
+);
+
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
+const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
+
+const App = () => {
+  return (
+    <Elements stripe={stripePromise}>
+      <InjectedCheckoutForm />
+    </Elements>
+  );
+};
+
+export default App;

--- a/examples/hooks/6-FPX.js
+++ b/examples/hooks/6-FPX.js
@@ -1,0 +1,109 @@
+import React, {useState} from 'react';
+import {loadStripe} from '@stripe/stripe-js';
+import {FpxBankElement, Elements, useElements, useStripe} from '../../src';
+
+import {logEvent, Result, ErrorResult} from '../util';
+import '../styles/common.css';
+
+const ELEMENT_OPTIONS = {
+  accountHolderType: 'individual',
+  classes: {
+    base: 'StripeElementFpx',
+    focus: 'StripeElementFpx--focus',
+  },
+  style: {
+    base: {
+      padding: '10px 14px',
+      fontSize: '18px',
+      color: '#424770',
+      letterSpacing: '0.025em',
+      '::placeholder': {
+        color: '#aab7c4',
+      },
+    },
+    invalid: {
+      color: '#9e2146',
+    },
+  },
+};
+
+const CheckoutForm = () => {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [name, setName] = useState('');
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [paymentMethod, setPaymentMethod] = useState(null);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (!stripe || !elements) {
+      // Stripe.js has not loaded yet. Make sure to disable
+      // form submission until Stripe.js has loaded.
+      return;
+    }
+
+    const fpxBankElement = elements.getElement(FpxBankElement);
+
+    const payload = await stripe.createPaymentMethod({
+      type: 'fpx',
+      fpx: fpxBankElement,
+      billing_details: {
+        name,
+      },
+    });
+
+    if (payload.error) {
+      console.log('[error]', payload.error);
+      setErrorMessage(payload.error.message);
+      setPaymentMethod(null);
+    } else {
+      console.log('[PaymentMethod]', payload.paymentMethod);
+      setPaymentMethod(payload.paymentMethod);
+      setErrorMessage(null);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label htmlFor="name">Full Name</label>
+      <input
+        id="name"
+        required
+        placeholder="Jenny Rosen"
+        value={name}
+        onChange={(e) => {
+          setName(e.target.value);
+        }}
+      />
+      <label htmlFor="fpx">FPX Bank</label>
+      <FpxBankElement
+        id="fpx"
+        onBlur={logEvent('blur')}
+        onChange={logEvent('change')}
+        onFocus={logEvent('focus')}
+        onReady={logEvent('ready')}
+        options={ELEMENT_OPTIONS}
+      />
+      {errorMessage && <ErrorResult>{errorMessage}</ErrorResult>}
+      {paymentMethod && <Result>Got PaymentMethod: {paymentMethod.id}</Result>}
+      <button type="submit" disabled={!stripe}>
+        Pay
+      </button>
+    </form>
+  );
+};
+
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
+const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
+
+const App = () => {
+  return (
+    <Elements stripe={stripePromise}>
+      <CheckoutForm />
+    </Elements>
+  );
+};
+
+export default App;

--- a/examples/styles/common.css
+++ b/examples/styles/common.css
@@ -102,7 +102,8 @@ More info: https://stripe.com/docs/stripe-js/reference#element-options
 */
 
 .StripeElement,
-.StripeElementIdeal {
+.StripeElementIdeal,
+.StripeElementFpx {
   display: block;
   margin: 10px 0 20px 0;
   max-width: 500px;
@@ -114,7 +115,8 @@ More info: https://stripe.com/docs/stripe-js/reference#element-options
 }
 
 .StripeElement--focus,
-.StripeElementIdeal--focus {
+.StripeElementIdeal--focus,
+.StripeElementFpx--focus {
   box-shadow: rgba(50, 50, 93, 0.109804) 0px 4px 6px,
     rgba(0, 0, 0, 0.0784314) 0px 1px 3px;
   -webkit-transition: all 150ms ease;
@@ -126,6 +128,7 @@ More info: https://stripe.com/docs/stripe-js/reference#element-options
   opacity: 0.6;
 }
 
-.StripeElementIdeal {
+.StripeElementIdeal,
+.StripeElementFpx {
   padding: 0;
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@storybook/addons": "^5.2.6",
     "@storybook/preset-typescript": "^1.2.0",
     "@storybook/react": "^5.2.6",
-    "@stripe/stripe-js": "1.0.0-beta.8",
+    "@stripe/stripe-js": "1.0.0-beta.9",
     "@types/enzyme": "^3.10.4",
     "@types/jest": "^25.1.1",
     "@types/react": "^16.9.19",
@@ -105,7 +105,7 @@
     "typescript": "^3.7.5"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": "1.0.0-beta.8",
+    "@stripe/stripe-js": "1.0.0-beta.9",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   CardNumberElementComponent,
   CardExpiryElementComponent,
   CardCvcElementComponent,
+  FpxBankElementComponent,
   IbanElementComponent,
   IdealBankElementComponent,
   PaymentRequestButtonElementComponent,
@@ -47,6 +48,14 @@ export const CardExpiryElement: CardExpiryElementComponent = createElementCompon
  */
 export const CardCvcElement: CardCvcElementComponent = createElementComponent(
   'cardCvc',
+  isServer
+);
+
+/**
+ * @docs https://stripe.com/docs/stripe-js/react#element-components
+ */
+export const FpxBankElement: FpxBankElementComponent = createElementComponent(
+  'fpxBank',
   isServer
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import createElementComponent from './components/createElementComponent';
 import {
+  AuBankAccountElementComponent,
   CardElementComponent,
   CardNumberElementComponent,
   CardExpiryElementComponent,
@@ -18,6 +19,17 @@ export {
 } from './components/Elements';
 
 const isServer = typeof window === 'undefined';
+
+/**
+ * Requires beta access:
+ * Contact [Stripe support](https://support.stripe.com/) for more information.
+ *
+ * @docs https://stripe.com/docs/stripe-js/react#element-components
+ */
+export const AuBankAccountElement: AuBankAccountElementComponent = createElementComponent(
+  'auBankAccount',
+  isServer
+);
 
 /**
  * @docs https://stripe.com/docs/stripe-js/react#element-components

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,6 +111,27 @@ export interface CardCvcElementProps extends ElementProps {
 
 export type CardCvcElementComponent = FunctionComponent<CardCvcElementProps>;
 
+export interface FpxBankElementProps extends ElementProps {
+  /**
+   * An object containing [Element configuration options](https://stripe.com/docs/js/elements_object/create_element?type=fpxBank).
+   */
+  options?: stripeJs.StripeFpxBankElementOptions;
+
+  /**
+   * Triggered when data exposed by this Element is changed (e.g., when there is an error).
+   * For more information, refer to the [Stripe.js reference](https://stripe.com/docs/js/element/events/on_change?type=fpxBankElement).
+   */
+  onChange?: (event: stripeJs.StripeFpxBankElementChangeEvent) => any;
+
+  /**
+   * Triggered when the Element is fully rendered and can accept imperative `element.focus()` calls.
+   * Called with a reference to the underlying [Element instance](https://stripe.com/docs/js/element).
+   */
+  onReady?: (element: stripeJs.StripeFpxBankElement) => any;
+}
+
+export type FpxBankElementComponent = FunctionComponent<FpxBankElementProps>;
+
 export interface IbanElementProps extends ElementProps {
   /**
    * An object containing [Element configuration options](https://stripe.com/docs/js/elements_object/create_element?type=iban).
@@ -212,6 +233,14 @@ declare module '@stripe/stripe-js' {
     getElement(
       component: CardExpiryElementComponent
     ): stripeJs.StripeCardExpiryElement | null;
+
+    /**
+     * Returns the underlying [element instance](https://stripe.com/docs/js/elements_object/create_element?type=fpxBank) for the `FpxBankElement` component in the current [Elements](https://stripe.com/docs/stripe-js/react#elements-provider) provider tree.
+     * Returns `null` if no `FpxBankElement` is rendered in the current `Elements` provider tree.
+     */
+    getElement(
+      component: FpxBankElementComponent
+    ): stripeJs.StripeFpxBankElement | null;
 
     /**
      * Returns the underlying [element instance](https://stripe.com/docs/js/elements_object/create_element?type=card) for the `IbanElement` component in the current [Elements](https://stripe.com/docs/stripe-js/react#elements-provider) provider tree.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,29 @@ export interface ElementProps {
   onFocus?: () => any;
 }
 
+export interface AuBankAccountElementProps extends ElementProps {
+  /**
+   * An object containing [Element configuration options](https://stripe.com/docs/js/elements_object/create_element?type=auBankAccount).
+   */
+  options?: stripeJs.StripeAuBankAccountElementOptions;
+
+  /**
+   * Triggered when data exposed by this Element is changed (e.g., when there is an error).
+   * For more information, refer to the [Stripe.js reference](https://stripe.com/docs/js/element/events/on_change?type=auBankAccountElement).
+   */
+  onChange?: (event: stripeJs.StripeAuBankAccountElementChangeEvent) => any;
+
+  /**
+   * Triggered when the Element is fully rendered and can accept imperative `element.focus()` calls.
+   * Called with a reference to the underlying [Element instance](https://stripe.com/docs/js/element).
+   */
+  onReady?: (element: stripeJs.StripeAuBankAccountElement) => any;
+}
+
+export type AuBankAccountElementComponent = FunctionComponent<
+  AuBankAccountElementProps
+>;
+
 export interface CardElementProps extends ElementProps {
   /**
    * An object containing [Element configuration options](https://stripe.com/docs/js/elements_object/create_element?type=card).
@@ -202,6 +225,17 @@ export type PaymentRequestButtonElementComponent = FunctionComponent<
 
 declare module '@stripe/stripe-js' {
   interface StripeElements {
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Returns the underlying [element instance](https://stripe.com/docs/js/elements_object/create_element?type=auBankAccount) for the `AuBankAccountElement` component in the current [Elements](https://stripe.com/docs/stripe-js/react#elements-provider) provider tree.
+     * Returns `null` if no `AuBankAccountElement` is rendered in the current `Elements` provider tree.
+     */
+    getElement(
+      component: AuBankAccountElementComponent
+    ): stripeJs.StripeAuBankAccountElement | null;
+
     /**
      * Returns the underlying [element instance](https://stripe.com/docs/js/elements_object/create_element?type=card) for the `CardElement` component in the current [Elements](https://stripe.com/docs/stripe-js/react#elements-provider) provider tree.
      * Returns `null` if no `CardElement` is rendered in the current `Elements` provider tree.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1635,10 +1635,10 @@
     telejson "^3.2.0"
     util-deprecate "^1.0.2"
 
-"@stripe/stripe-js@1.0.0-beta.8":
-  version "1.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.0.0-beta.8.tgz#571a5e5ddd463bc404078ea8590afdac7551e336"
-  integrity sha512-utG/HOJz7UBqiudvlLjy1TQJrPC7D0r8l1Cnwo1XtESL5ashEjrIiDYNEcQSTwjMMieHhok4GlYfxYQAZ6etnQ==
+"@stripe/stripe-js@1.0.0-beta.9":
+  version "1.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.0.0-beta.9.tgz#eac62e4a16a1883929a8c7f53be21916a8507823"
+  integrity sha512-LL7jaM7WmhTWJ71elVae46zbbP/lgpktCdSh+rS46S/1F9dDiYLHPGpoaVKnMqpmAy7XJYqVQrW5AV8k1XGynw==
 
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"


### PR DESCRIPTION
### Summary & motivation
* Add components and types for `auBankAccount` and `fpxBank` elements.
* Add an FPX example; no auBankAccount example for now since it is still in beta

[this template]:
  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md

### Testing & documentation
I manually tested that both Elements wired up correctly.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
