### PR TITLE
Force babel to transpile ts and tsx files

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,14 @@ export default [
       {file: pkg.main, format: 'cjs'},
       {file: pkg.module, format: 'es'},
     ],
-    plugins: [ts(), resolve(), babel(), commonjs()],
+    plugins: [
+      ts(),
+      resolve(),
+      babel({
+        extensions: ['.ts', '.tsx'],
+      }),
+      commonjs(),
+    ],
   },
   // UMD build with inline PropTypes
   {
@@ -30,7 +37,14 @@ export default [
         },
       },
     ],
-    plugins: [ts(), resolve(), babel(), commonjs()],
+    plugins: [
+      ts(),
+      resolve(),
+      babel({
+        extensions: ['.ts', '.tsx'],
+      }),
+      commonjs(),
+    ],
   },
   // Minified UMD Build without PropTypes
   {
@@ -49,7 +63,9 @@ export default [
     plugins: [
       ts(),
       resolve(),
-      babel(),
+      babel({
+        extensions: ['.ts', '.tsx'],
+      }),
       replace({'process.env.NODE_ENV': JSON.stringify('production')}),
       commonjs(),
       terser(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -64,7 +64,7 @@ export default [
       ts(),
       resolve(),
       babel({
-        extensions: ['.ts', '.tsx'],
+        extensions: ['.ts', '.js', '.tsx', '.jsx'],
       }),
       replace({'process.env.NODE_ENV': JSON.stringify('production')}),
       commonjs(),


### PR DESCRIPTION
### Summary & motivation
Ensure that babel transpiles TypeScript files to ES5. 

Fixes #50

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation

Investigated build output and tested locally.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
