### PR TITLE
add js and jsx to rollup configs

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ export default [
       ts(),
       resolve(),
       babel({
-        extensions: ['.ts', '.tsx'],
+        extensions: ['.ts', '.js', '.tsx', '.jsx'],
       }),
       commonjs(),
     ],
@@ -41,7 +41,7 @@ export default [
       ts(),
       resolve(),
       babel({
-        extensions: ['.ts', '.tsx'],
+        extensions: ['.ts', '.js', '.tsx', '.jsx'],
       }),
       commonjs(),
     ],


### PR DESCRIPTION
### Summary & motivation
Expand babel to transpile `js` and `jsx` in all rollup configs. Fix from #51 
