### PR TITLE
chore: remove flow config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,2 +1,0 @@
-[libs]
-src/types/

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,2 +1,2 @@
 [libs]
-src/decls/
+src/types/


### PR DESCRIPTION
Not sure whether this will work for flow users, but since the `decls` folder has been renamed `types` it should probably be reflected here.
