### PR TITLE
Register package version with Stripe instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
             151001
           ]
         }
-      }
+      },
+      "_VERSION": true
     }
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,19 @@ import replace from 'rollup-plugin-replace';
 import ts from '@wessberg/rollup-plugin-ts';
 import pkg from './package.json';
 
+const PLUGINS = [
+  ts(),
+  resolve(),
+  babel({
+    extensions: ['.ts', '.js', '.tsx', '.jsx'],
+  }),
+  replace({
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    _VERSION: JSON.stringify(pkg.version),
+  }),
+  commonjs(),
+];
+
 export default [
   {
     input: 'src/index.ts',
@@ -14,14 +27,7 @@ export default [
       {file: pkg.main, format: 'cjs'},
       {file: pkg.module, format: 'es'},
     ],
-    plugins: [
-      ts(),
-      resolve(),
-      babel({
-        extensions: ['.ts', '.js', '.tsx', '.jsx'],
-      }),
-      commonjs(),
-    ],
+    plugins: PLUGINS,
   },
   // UMD build with inline PropTypes
   {
@@ -37,14 +43,7 @@ export default [
         },
       },
     ],
-    plugins: [
-      ts(),
-      resolve(),
-      babel({
-        extensions: ['.ts', '.js', '.tsx', '.jsx'],
-      }),
-      commonjs(),
-    ],
+    plugins: PLUGINS,
   },
   // Minified UMD Build without PropTypes
   {
@@ -60,15 +59,6 @@ export default [
         },
       },
     ],
-    plugins: [
-      ts(),
-      resolve(),
-      babel({
-        extensions: ['.ts', '.js', '.tsx', '.jsx'],
-      }),
-      replace({'process.env.NODE_ENV': JSON.stringify('production')}),
-      commonjs(),
-      terser(),
-    ],
+    plugins: [...PLUGINS, terser()],
   },
 ];

--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -160,6 +160,16 @@ export const Elements: FunctionComponent<ElementsProps> = ({
     };
   }, []);
 
+  React.useEffect(() => {
+    const anyStripe: any = ctx.stripe;
+
+    if (!anyStripe || !anyStripe._registerWrapper) {
+      return;
+    }
+
+    anyStripe._registerWrapper({name: 'react-stripe-js', version: _VERSION});
+  }, [ctx.stripe]);
+
   return (
     <ElementsContext.Provider value={ctx}>{children}</ElementsContext.Provider>
   );

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,4 @@
+// A magic global reflecting the current package version defined in
+// `package.json`. This will be rewritten at build time as a string literal
+// when rollup is run (via `@plugin/rollup-replace`).
+declare const _VERSION: string;

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -26,4 +26,5 @@ export const mockStripe = () => ({
   confirmCardPayment: jest.fn(),
   confirmCardSetup: jest.fn(),
   paymentRequest: jest.fn(),
+  _registerWrapper: jest.fn(),
 });


### PR DESCRIPTION
Registers the current package.json version with Stripe.js when a `Stripe` instance is first passed.