### PR TITLE
add preview-head.html with _VERSION to storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<script>const _VERSION = true;</script>


### PR DESCRIPTION
### Summary & motivation

I get the following error when bringing up storybook for this project.
`_VERSION is not defined`

Looks like storybook uses its own webpack config as opposed to the project's rollup config.

The fix is inspired by the way a global _VERSION=true was added to the jest config when _VERSION was introduced.

### Testing & documentation

Storybook started working after adding this change.