### PR TITLE
Include the required client secret in migrating.md

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -257,7 +257,7 @@ const CheckoutForm = (props) => {
     });
 
     // or confirmCardPayment - https://stripe.com/docs/js/payment_intents/confirm_card_payment
-    stripe.confirmCardPayment({
+    stripe.confirmCardPayment(paymentIntentClientSecret, {
       payment_method: {
         card: cardElement,
       },


### PR DESCRIPTION
### Summary & motivation

I noticed the required client secret was missing on the migration examples.