### PR TITLE
Add React 17 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "peerDependencies": {
     "@stripe/stripe-js": "^1.2.0",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   }
 }


### PR DESCRIPTION
### Summary & motivation
The motivation is to remove peer dependency warning when React 17 is installed. This is achieved by adding the peer dependency for React 17 to `package.json`.