### PR TITLE
Fix Element effect cleanup when using async stripe prop

### DIFF
--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from '@testing-library/react';
+import {render, act} from '@testing-library/react';
 
 import {Elements} from './Elements';
 import createElementComponent from './createElementComponent';
@@ -403,6 +403,21 @@ describe('createElementComponent', () => {
       );
 
       unmount2();
+      expect(mockElement.destroy).toHaveBeenCalled();
+    });
+
+    it('destroys an existing Element when the component unmounts with an async stripe prop', async () => {
+      const stripePromise = Promise.resolve(mockStripe);
+
+      const {unmount} = render(
+        <Elements stripe={stripePromise}>
+          <CardElement />
+        </Elements>
+      );
+
+      await act(() => stripePromise);
+
+      unmount();
       expect(mockElement.destroy).toHaveBeenCalled();
     });
   });

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -115,11 +115,9 @@ const createElementComponent = (
     }, [options]);
 
     React.useEffect(() => {
-      const element = elementRef.current;
-
       return () => {
-        if (element) {
-          element.destroy();
+        if (elementRef.current) {
+          elementRef.current.destroy();
         }
       };
     }, []);


### PR DESCRIPTION
### Summary & motivation

https://github.com/stripe/react-stripe-js/issues/152 reported an issue where Elements are not destroyed after being unmounted, causing errors when attempting to remount an Element of the same type later.

The issue was introduced in https://github.com/stripe/react-stripe-js/pull/147. We close over the current Element ref in the effect cleanup function when the component first mounts. But if the Element doesn't exist yet, which happens when an async `stripe` prop is passed to the `<Elements>` provider, there is no Element to clean up when the component unmounts.

### Testing & documentation

We tested whether the Element was destroyed in the sync case, but not in the async case. I added a test for the async case.