### PR TITLE
[React@17] useLayoutEffect for synchronous cleanup

### DIFF
--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -121,6 +121,33 @@ describe('createElementComponent', () => {
       false
     );
 
+
+    it('Can remove and add CardElement at the same time', () => {
+      let cardMounted = false;
+      mockElement.mount.mockImplementation(()=> {
+        if(cardMounted){
+          throw new Error('Card already mounted');
+        }
+        cardMounted = true;
+      });
+      mockElement.destroy.mockImplementation(()=> {
+        cardMounted = false;
+      });
+
+      const {rerender} = render(
+        <Elements stripe={mockStripe}>
+          <CardElement key={"1"} />
+        </Elements>
+      );
+      rerender(
+        <Elements stripe={mockStripe}>
+          <CardElement key={"2"} />
+        </Elements>
+      );
+
+      expect(mockElement.mount).toHaveBeenCalledTimes(2);
+    });
+
     it('gives the element component a proper displayName', () => {
       expect(CardElement.displayName).toBe('CardElement');
     });

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -114,7 +114,7 @@ const createElementComponent = (
       }
     }, [options]);
 
-    React.useEffect(() => {
+    React.useLayoutEffect(() => {
       return () => {
         if (elementRef.current) {
           elementRef.current.destroy();


### PR DESCRIPTION
### Summary & motivation

Fixes race condition of adding and removing a card element at the same time in React 17.
https://github.com/stripe/react-stripe-js/issues/154

### Testing & documentation

https://codesandbox.io/s/gracious-dawn-txrz7?file=/src/App.js
Reproduce of existing issue and tested it with fix.
