### PR TITLE
Adding support for `afterpayClearpayMessage` Element

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@storybook/addons": "^5.2.6",
     "@storybook/preset-typescript": "^1.2.0",
     "@storybook/react": "^5.2.6",
-    "@stripe/stripe-js": "^1.2.0",
+    "@stripe/stripe-js": "^1.13.0",
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.2.3",
     "@testing-library/react-hooks": "^4.0.0",
@@ -107,7 +107,7 @@
     "typescript": "^3.7.5"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": "^1.2.0",
+    "@stripe/stripe-js": "^1.13.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   IbanElementComponent,
   IdealBankElementComponent,
   PaymentRequestButtonElementComponent,
+  AfterpayClearpayMessageElementComponent,
 } from './types';
 
 export * from './types'
@@ -94,5 +95,13 @@ export const IdealBankElement: IdealBankElementComponent = createElementComponen
  */
 export const PaymentRequestButtonElement: PaymentRequestButtonElementComponent = createElementComponent(
   'paymentRequestButton',
+  isServer
+);
+
+/**
+ * @docs https://stripe.com/docs/stripe-js/react#element-components
+ */
+export const AfterpayClearpayMessageElement: AfterpayClearpayMessageElementComponent = createElementComponent(
+  'afterpayClearpayMessage',
   isServer
 );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -263,6 +263,33 @@ export type PaymentRequestButtonElementComponent = FunctionComponent<
   PaymentRequestButtonElementProps
 >;
 
+export interface AfterpayClearpayMessageElementProps {
+  /**
+   * Passes through to the [Element’s container](https://stripe.com/docs/js/element/the_element_container).
+   */
+  id?: string;
+
+  /**
+   * Passes through to the [Element’s container](https://stripe.com/docs/js/element/the_element_container).
+   */
+  className?: string;
+
+  /**
+   * An object containing [Element configuration options](https://stripe.com/docs/js/elements_object/create_element?type=afterpayClearpayMessage).
+   */
+  options?: stripeJs.StripeAfterpayClearpayMessageElementOptions;
+
+  /**
+   * Triggered when the Element has been fully loaded, after initial method calls have been fired.
+   * Called with a reference to the underlying [Element instance](https://stripe.com/docs/js/element).
+   */
+  onReady?: (element: stripeJs.StripeAfterpayClearpayMessageElement) => any;
+}
+
+export type AfterpayClearpayMessageElementComponent = FunctionComponent<
+  AfterpayClearpayMessageElementProps
+>;
+
 declare module '@stripe/stripe-js' {
   interface StripeElements {
     /**
@@ -339,5 +366,13 @@ declare module '@stripe/stripe-js' {
     getElement(
       component: PaymentRequestButtonElementComponent
     ): stripeJs.StripePaymentRequestButtonElement | null;
+
+    /**
+     * Returns the underlying [element instance](https://stripe.com/docs/js/elements_object/create_element?type=card) for the `PaymentRequestButtonElement` component in the current [Elements](https://stripe.com/docs/stripe-js/react#elements-provider) provider tree.
+     * Returns `null` if no `PaymentRequestButtonElement` is rendered in the current `Elements` provider tree.
+     */
+    getElement(
+      component: AfterpayClearpayMessageElementComponent
+    ): stripeJs.StripeAfterpayClearpayMessageElement | null;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,10 +1749,10 @@
     telejson "^3.2.0"
     util-deprecate "^1.0.2"
 
-"@stripe/stripe-js@^1.2.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.11.0.tgz#00e812d72a7760dae08237875066d263671478ee"
-  integrity sha512-SDNZKuETBEVkernd1tq8tL6wNfVKrl24Txs3p+4NYxoaIbNaEO7mrln/2Y/WRcQBWjagvhDIM5I6+X1rfK0qhQ==
+"@stripe/stripe-js@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.13.0.tgz#7737a39d3d909c6d7164e604e0eb5828ab14cb0d"
+  integrity sha512-8H3yH+jqZ7pWe34WvOo0L0pYsjaveb3Kw9dfoHUMnUwHWZ7ku4SwWZD1D8wQSnTx5se4iVUuKRsLvEwkUaUjSw==
 
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"


### PR DESCRIPTION
### Summary & motivation
Added support for new `afterpayClearpayMessage` Element.
<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation
Verified that `typecheck` passes.
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
