### PR TITLE
Register library information with registerAppInfo

### DIFF
--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -163,11 +163,17 @@ export const Elements: FunctionComponent<ElementsProps> = ({
   React.useEffect(() => {
     const anyStripe: any = ctx.stripe;
 
-    if (!anyStripe || !anyStripe._registerWrapper) {
+    if (!anyStripe || !anyStripe._registerWrapper || !anyStripe.registerAppInfo) {
       return;
     }
 
     anyStripe._registerWrapper({name: 'react-stripe-js', version: _VERSION});
+
+    anyStripe.registerAppInfo({
+      name: 'react-stripe-js',
+      version: _VERSION,
+      url: 'https://stripe.com/docs/stripe-js/react',
+    })
   }, [ctx.stripe]);
 
   return (

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -26,5 +26,6 @@ export const mockStripe = () => ({
   confirmCardPayment: jest.fn(),
   confirmCardSetup: jest.fn(),
   paymentRequest: jest.fn(),
+  registerAppInfo: jest.fn(),
   _registerWrapper: jest.fn(),
 });


### PR DESCRIPTION
### Summary & motivation
This PR calls `stripe.registerAppInfo` to track `react-stripe-js` usage. It is part of the workstream to track OSS library attribution.
<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation
Tested out manually
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
