### PR TITLE
Fix lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "yarn run lint && yarn run lint:prettier && yarn run test:unit && yarn run typecheck",
     "test:unit": "jest",
-    "lint": "eslint '{src,examples}/**/*.{ts,tsx,js}'",
+    "lint": "eslint --max-warnings=0 '{src,examples}/**/*.{ts,tsx,js}'",
     "lint:prettier": "prettier './**/*.js' './**/*.css' './**/*.md' --list-different",
     "typecheck": "tsc",
     "build": "yarn run clean && yarn run rollup -c && yarn checkimport",

--- a/src/components/Elements.test.tsx
+++ b/src/components/Elements.test.tsx
@@ -293,7 +293,7 @@ describe('Elements', () => {
   test('throws when trying to call useElements outside of Elements context', () => {
     const {result} = renderHook(() => useElements());
 
-    expect(result.error!.message).toBe(
+    expect(result.error && result.error.message).toBe(
       'Could not find Elements context; You need to wrap the part of your app that calls useElements() in an <Elements> provider.'
     );
   });
@@ -301,7 +301,7 @@ describe('Elements', () => {
   test('throws when trying to call useStripe outside of Elements context', () => {
     const {result} = renderHook(() => useStripe());
 
-    expect(result.error!.message).toBe(
+    expect(result.error && result.error.message).toBe(
       'Could not find Elements context; You need to wrap the part of your app that calls useStripe() in an <Elements> provider.'
     );
   });


### PR DESCRIPTION
### Summary & motivation

Fix two lint warnings and stop allowing warnings to linger. Keep that code ✨ 

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation

Ran `yarn lint` with no errors and no warnings
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
