### PR TITLE
update to latest stripe-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-react": "^7.7.0",
     "@storybook/react": "^6.2.9",
-    "@stripe/stripe-js": "^1.13.0",
+    "@stripe/stripe-js": "^1.18.0",
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.2.3",
     "@testing-library/react-hooks": "^4.0.0",
@@ -103,7 +103,7 @@
     "typescript": "^3.7.5"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": "^1.13.0",
+    "@stripe/stripe-js": "^1.18.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2807,10 +2807,10 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
-"@stripe/stripe-js@^1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.13.0.tgz#7737a39d3d909c6d7164e604e0eb5828ab14cb0d"
-  integrity sha512-8H3yH+jqZ7pWe34WvOo0L0pYsjaveb3Kw9dfoHUMnUwHWZ7ku4SwWZD1D8wQSnTx5se4iVUuKRsLvEwkUaUjSw==
+"@stripe/stripe-js@^1.18.0":
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.18.0.tgz#687268d7cd68b44b92b86300d7c7f2a6e4df0b98"
+  integrity sha512-yBRHAMKHnF3kbzv0tpKB82kSow43wW5qXLK8ofg3V9NaaCyObSTO7wJfktWAtG/NBgkJOdUL+pV8dHBj0qvDkQ==
 
 "@testing-library/dom@^7.28.1":
   version "7.29.2"


### PR DESCRIPTION
### Summary & motivation

Update [@stripe/stripe-js](https://github.com/stripe/stripe-js) to latest version ([v1.18.0](https://github.com/stripe/stripe-js/releases/tag/v1.18.0)) so that we can add React bindings for the Payment Element and support updating options passed to the `Elements` provider.

### Testing & documentation

Just a dependency version bump. Existing tests still pass.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
