### PR TITLE
utilize types for Payment element

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -296,7 +296,26 @@ export type EpsBankElementComponent = FunctionComponent<
   >;
 
 export interface PaymentElementProps extends ElementProps {
-  options?: any;
+  /**
+   * An object containing Element configuration options.
+   */
+  options?: stripeJs.StripePaymentElementOptions;
+
+  /**
+   * Triggered when data exposed by this Element is changed.
+   */
+  onChange?: (event: stripeJs.StripePaymentElementChangeEvent) => any;
+
+  /**
+   * Triggered when the Element is fully rendered and can accept imperative `element.focus()` calls.
+   * Called with a reference to the underlying [Element instance](https://stripe.com/docs/js/element).
+   */
+  onReady?: (element: stripeJs.StripePaymentElement) => any;
+
+  /**
+   * Triggered when the escape key is pressed within the Element.
+   */
+  onEscape?: () => any;
 }
 
 export type PaymentElementComponent = FunctionComponent<PaymentElementProps>;


### PR DESCRIPTION
### Summary & motivation

Utilize and expose the types provided by `@stripe/stripe-js` for the `PaymentElement` in the `PaymentElementComponent` type.

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation

Types only change. We don't currently have types level tests in React Stripe.js.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
