### PR TITLE
Friendly spellcheck in comments

### DIFF
--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -72,7 +72,7 @@ const createElementComponent = (
         element.on('focus', callOnFocus);
         element.on('escape', callOnEscape);
 
-        // Users can pass an an onClick prop on any Element component
+        // Users can pass an onClick prop on any Element component
         // just as they could listen for the `click` event on any Element,
         // but only the PaymentRequestButton will actually trigger the event.
         (element as any).on('click', callOnClick);


### PR DESCRIPTION
### Summary & motivation

Remove duplicate `"an"` in comments for custom `onClick` handler.

Change `// Users can pass an an onClick prop on any Element component` to `// Users can pass an onClick prop on any Element component`.

### Testing & documentation

**How did you test this change?**

No testing needed. Actual code not effected.

