### PR TITLE
Avoid overwriting class names set by the Element instance

### DIFF
--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -465,5 +465,77 @@ describe('createElementComponent', () => {
         style: {base: {fontSize: '30px'}},
       });
     });
+
+    it('does not overwrite classnames set by the Element instance', () => {
+      const {container, rerender} = render(
+        <Elements stripe={mockStripe}>
+          <CardElement className="bar" />
+        </Elements>
+      );
+      const elementContainer = container.firstChild as Element;
+
+      expect(elementContainer.classList).toHaveLength(1);
+      expect(elementContainer).toHaveClass('bar');
+
+      elementContainer.classList.add('StripeElement', 'StripeElement--empty');
+      rerender(
+        <Elements stripe={mockStripe}>
+          <CardElement className="bar baz" />
+        </Elements>
+      );
+
+      expect(elementContainer.classList).toHaveLength(4);
+      expect(elementContainer).toHaveClass(
+        'bar',
+        'baz',
+        'StripeElement',
+        'StripeElement--empty'
+      );
+
+      rerender(
+        <Elements stripe={mockStripe}>
+          <CardElement className="baz" />
+        </Elements>
+      );
+
+      expect(elementContainer.classList).toHaveLength(3);
+      expect(elementContainer).toHaveClass(
+        'baz',
+        'StripeElement',
+        'StripeElement--empty'
+      );
+    });
+
+    // This should work, but does not
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('does not remove classnames removed from the className prop that were also set by the Element instance', () => {
+      const {container, rerender} = render(
+        <Elements stripe={mockStripe}>
+          <CardElement className="foo StripeElement StripeElement--empty" />
+        </Elements>
+      );
+      const elementContainer = container.firstChild as Element;
+
+      expect(elementContainer.classList).toHaveLength(3);
+      expect(elementContainer).toHaveClass(
+        'foo',
+        'StripeElement',
+        'StripeElement--empty'
+      );
+
+      elementContainer.classList.add('StripeElement', 'StripeElement--empty');
+      rerender(
+        <Elements stripe={mockStripe}>
+          <CardElement className="foo" />
+        </Elements>
+      );
+
+      expect(elementContainer.classList).toHaveLength(3);
+      expect(elementContainer).toHaveClass(
+        'foo',
+        'StripeElement',
+        'StripeElement--empty'
+      );
+    });
   });
 });


### PR DESCRIPTION
This is an attempt at fixing #267. I'm wary of actually merging this—just opening for discussion.

The solution is described in the diff. One concern is demonstrated by the skipped test I added, which will fail: if the React application uses the `className` to set a class that is also set by the Elements instance, then removes that class from the `className` prop, the class will be removed from the DOM even though the Elements instance still wants it applied. This wouldn't be a regression since it is exactly the existing behavior that #267 describes, but it wouldn't be a fix either. 

Another concern is just general FUD about setting a class in a layout effect rather than during render. I can't actually think of a scenario in which this would break, but it different behavior which I'm sure is at least observable by a calling React application.