### PR TITLE
Fixed `Elements` `FunctionalComponent` React 18 types bug

### DIFF
--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -1,5 +1,10 @@
 // Must use `import *` or named imports for React's types
-import {FunctionComponent, ReactElement, ReactNode} from 'react';
+import {
+  FunctionComponent,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+} from 'react';
 import * as stripeJs from '@stripe/stripe-js';
 
 import React from 'react';
@@ -102,7 +107,7 @@ interface PrivateElementsProps {
  *
  * @docs https://stripe.com/docs/stripe-js/react#elements-provider
  */
-export const Elements: FunctionComponent<ElementsProps> = (({
+export const Elements: FunctionComponent<PropsWithChildren<ElementsProps>> = (({
   stripe: rawStripeProp,
   options,
   children,
@@ -196,7 +201,7 @@ export const Elements: FunctionComponent<ElementsProps> = (({
   return (
     <ElementsContext.Provider value={ctx}>{children}</ElementsContext.Provider>
   );
-}) as FunctionComponent<ElementsProps>;
+}) as FunctionComponent<PropsWithChildren<ElementsProps>>;
 
 Elements.propTypes = {
   stripe: PropTypes.any,


### PR DESCRIPTION
### Summary & motivation

I am of course aware that more work is needed to add support for React 18 (#273), however for those currently running React 18 & TypeScript (`@types/react`) may run into an error with the `Elements` component as a change in React 18 to the types has been [the removal of the optional `children` property](https://twitter.com/reactjs/status/1512453969490108418).

This PR is designed to serve as a quick fix until complete React 18 support has been implemented.

### Testing & documentation

To test that these changes have not affected the functionality of the library I deployed a new GitHub Codespace & performed the following steps:
 - Ran `yarn install`
 - Ran `yarn build`
 - Ran `yarn test`
 - Ran `yarn test` (To test current HEAD works)
 - Updated `src/components/Elements.tsx` to wrap `Elements` component prop types with `PropsWithChildren`
 - Ran `yarn build`
 - Ran `yarn test`