### PR TITLE
fix: children prop typing on Elements component

### DIFF
--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -1,5 +1,10 @@
 // Must use `import *` or named imports for React's types
-import {FunctionComponent, ReactElement, ReactNode} from 'react';
+import {
+  FunctionComponent,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+} from 'react';
 import * as stripeJs from '@stripe/stripe-js';
 
 import React from 'react';
@@ -102,7 +107,7 @@ interface PrivateElementsProps {
  *
  * @docs https://stripe.com/docs/stripe-js/react#elements-provider
  */
-export const Elements: FunctionComponent<ElementsProps> = (({
+export const Elements: FunctionComponent<PropsWithChildren<ElementsProps>> = (({
   stripe: rawStripeProp,
   options,
   children,
@@ -196,7 +201,7 @@ export const Elements: FunctionComponent<ElementsProps> = (({
   return (
     <ElementsContext.Provider value={ctx}>{children}</ElementsContext.Provider>
   );
-}) as FunctionComponent<ElementsProps>;
+}) as FunctionComponent<PropsWithChildren<ElementsProps>>;
 
 Elements.propTypes = {
   stripe: PropTypes.any,


### PR DESCRIPTION
### Summary & motivation

The new `@types/react@^18` package ships with [several breaking changes](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210). One such change is that `children` prop is no longer automatically included as part of the `FunctionalComponent` (ie `FC`) typing. Components need to opt-in to the `children` prop now.

The `Elements` component uses `children` and consumers who have upgraded to `@types/react@^18` will get an error `<Element />` does not have `children`.

This change adds `children` component typing that is compatible with `@types/react@^18` changes.

---

Side note: This was originally provided by @NuroDev via #280, but the author hasn't signed the CLA and isn't responding to the request to sign the CLA. I'm submitting this fix in order to provide a fix to the community running into this issue.

### Testing & documentation

This is only a typing change, but:

1. Built the package via `yarn build`.
2. Manually linked the package (via `yarn link`) into a project that uses `@stripe/react-stripe-js` and `@types/react@^18`.
3. Verified typing and usage of `<Elements />` component.
4. Verified no TypeScript errors.
