### PR TITLE
Added `elements()` async initialization error raising

### DIFF
--- a/examples/class-components/9-Elements-With-Error.js
+++ b/examples/class-components/9-Elements-With-Error.js
@@ -1,0 +1,90 @@
+// This example shows how to catch `Elements` errors using React Error Boundaries
+
+import React from 'react';
+import {loadStripe} from '@stripe/stripe-js';
+import {Elements, PaymentElement} from '../../src';
+import '../styles/common.css';
+
+class CheckoutForm extends React.Component {
+  handleSubmit = async (event) => {
+    // We don't want to let default form submission happen here,
+    // which would refresh the page.
+    event.preventDefault();
+
+    const {stripe, elements} = this.props;
+
+    if (!stripe || !elements) {
+      // Stripe.js has not yet loaded.
+      // Make sure to disable form submission until Stripe.js has loaded.
+      return;
+    }
+
+    const result = await stripe.confirmPayment({
+      //`Elements` instance that was used to create the Payment Element
+      elements,
+      confirmParams: {
+        return_url: 'https://example.com/order/123/complete',
+      },
+    });
+
+    if (result.error) {
+      // Show error to your customer (for example, payment details incomplete)
+      console.log(result.error.message);
+    } else {
+      // Your customer will be redirected to your `return_url`. For some payment
+      // methods like iDEAL, your customer will be redirected to an intermediate
+      // site first to authorize the payment, then redirected to the `return_url`.
+    }
+  };
+
+  render() {
+    return (
+      <form onSubmit={this.handleSubmit}>
+        <PaymentElement />
+        <button disabled={!this.props.stripe}>Submit</button>
+      </form>
+    );
+  }
+}
+
+// Make sure to call `loadStripe` outside of a component’s render to avoid
+// recreating the `Stripe` object on every render.
+const stripePromise = loadStripe('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {hasError: false};
+  }
+
+  static getDerivedStateFromError() {
+    // Update state so the next render will show the fallback UI.
+    return {hasError: true};
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return <h1>Something went wrong.</h1>;
+    }
+
+    return this.props.children;
+  }
+}
+
+const App = () => {
+  const options = {
+    // passing the client secret obtained from the server
+    clientSecret: '{{CLIENT_SECRET}}',
+  };
+
+  return (
+    <ErrorBoundary>
+      <Elements stripe={stripePromise} options={options} raiseErrors>
+        <CheckoutForm />
+      </Elements>
+    </ErrorBoundary>
+  );
+};
+
+export default App;


### PR DESCRIPTION
### Summary & motivation

Currently, if some error happens during asynchronous initialization of `stripe.elements()`, an error won't be propagated within the `React` component. I've prepared [an example on codesandbox](https://codesandbox.io/s/react-stripe-js-forked-t7j5gc?file=/src/index.js): we have `Uncaught (in promise) IntegrationError: Invalid value for elements()...`, the error is not caught by parent `ErrorBoundary` component.

Although having such an error probably indicates integration issues, I suggest (optionally) throwing an error within this component. Moreover, it seems that in `'sync'` mode error is already being thrown.

### API review

#### Summary

Now `<Elements />` component will throw an error in case there was an issue initializing `stripe.elements` in `'async'` mode. In order not to crash the existing codebase I also introduced an additional `<Elements raiseError />` parameter, but this will not have to be done if the update is marked as minor.

#### Alternatives

Similar result can be achieved by introducing some sort of `<Elements onError={() => ...} />` prop, although I thinking making `throw` is more natural as long as `Elements` component [already has it](https://github.com/stripe/react-stripe-js/blob/d5d3f09f35e2c7ac1515aa31216040649d227cfd/src/components/Elements.tsx#L31).

#### Scope

This change only affects `<Elements />` component on the step of its initializing.

#### Risks

From my point of view, the only risk is related to a new component error arising. I suggested providing some sort of `<Elements raiseError />` prop, although in this case, we should also check for this condition to raise errors in `'sync'` mode. There is an open discussion within #291 that usage of such errors should be documented which can be a argument towards introducing `raiseError` prop.

### Testing & documentation

For now, I've added [a new example](https://github.com/stripe/react-stripe-js/pull/294/files#diff-d1ed14d02fdb28ce057d45b47c5179fbbe3d6b462e1ecca0097e5f69731f090d) to the `Storybook` showing new changes in action. I'll also write an additional test to check error propagation in case maintainers will approve the overall idea.