### PR TITLE
Add `onLoadError` prop

### DIFF
--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -6,6 +6,7 @@ import createElementComponent from './createElementComponent';
 import * as mocks from '../../test/mocks';
 import {
   CardElementComponent,
+  PaymentElementComponent,
   PaymentRequestButtonElementComponent,
 } from '../types';
 
@@ -19,6 +20,7 @@ describe('createElementComponent', () => {
   let simulateEscape: any;
   let simulateReady: any;
   let simulateClick: any;
+  let simulateLoadError: any;
 
   beforeEach(() => {
     mockStripe = mocks.mockStripe();
@@ -46,6 +48,9 @@ describe('createElementComponent', () => {
           break;
         case 'click':
           simulateClick = fn;
+          break;
+        case 'loaderror':
+          simulateLoadError = fn;
           break;
         default:
           throw new Error('TestSetupError: Unexpected event registration.');
@@ -118,6 +123,10 @@ describe('createElementComponent', () => {
     );
     const PaymentRequestButtonElement: PaymentRequestButtonElementComponent = createElementComponent(
       'card',
+      false
+    );
+    const PaymentElement: PaymentElementComponent = createElementComponent(
+      'payment',
       false
     );
 
@@ -342,6 +351,26 @@ describe('createElementComponent', () => {
       const clickEventMock = Symbol('click');
       simulateClick(clickEventMock);
       expect(mockHandler2).toHaveBeenCalledWith(clickEventMock);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    it('propagates the Element`s loaderror event to the current onLoadError prop', () => {
+      const mockHandler = jest.fn();
+      const mockHandler2 = jest.fn();
+      const {rerender} = render(
+        <Elements stripe={mockStripe}>
+          <PaymentElement onLoadError={mockHandler} />
+        </Elements>
+      );
+      rerender(
+        <Elements stripe={mockStripe}>
+          <PaymentElement onLoadError={mockHandler2} />
+        </Elements>
+      );
+
+      const loadErrorEventMock = Symbol('loaderror');
+      simulateLoadError(loadErrorEventMock);
+      expect(mockHandler2).toHaveBeenCalledWith(loadErrorEventMock);
       expect(mockHandler).not.toHaveBeenCalled();
     });
 

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -26,6 +26,7 @@ interface PrivateElementProps {
   onEscape?: UnknownCallback;
   onReady?: UnknownCallback;
   onClick?: UnknownCallback;
+  onLoadError?: UnknownCallback;
   options?: UnknownOptions;
 }
 
@@ -49,6 +50,7 @@ const createElementComponent = (
     onChange = noop,
     onEscape = noop,
     onClick = noop,
+    onLoadError = noop,
   }) => {
     const {elements} = useElementsContextWithUseCase(`mounts <${displayName}>`);
     const elementRef = React.useRef<stripeJs.StripeElement | null>(null);
@@ -60,6 +62,7 @@ const createElementComponent = (
     const callOnClick = useCallbackReference(onClick);
     const callOnChange = useCallbackReference(onChange);
     const callOnEscape = useCallbackReference(onEscape);
+    const callOnLoadError = useCallbackReference(onLoadError);
 
     React.useLayoutEffect(() => {
       if (elementRef.current == null && elements && domNode.current != null) {
@@ -71,6 +74,11 @@ const createElementComponent = (
         element.on('blur', callOnBlur);
         element.on('focus', callOnFocus);
         element.on('escape', callOnEscape);
+
+        // Users can pass an onLoadError prop on any Element component
+        // just as they could listen for the `loaderror` event on any Element,
+        // but only certain Elements will trigger the event.
+        (element as any).on('loaderror', callOnLoadError);
 
         // Users can pass an onClick prop on any Element component
         // just as they could listen for the `click` event on any Element,
@@ -124,6 +132,7 @@ const createElementComponent = (
     onFocus: PropTypes.func,
     onReady: PropTypes.func,
     onClick: PropTypes.func,
+    onLoadError: PropTypes.func,
     options: PropTypes.object as any,
   };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 import {FunctionComponent} from 'react';
 import * as stripeJs from '@stripe/stripe-js';
+import {StripeError} from '@stripe/stripe-js';
 
 export interface ElementProps {
   /**
@@ -287,6 +288,14 @@ export interface LinkAuthenticationElementProps extends ElementProps {
    * Triggered when the escape key is pressed within the Element.
    */
   onEscape?: () => any;
+
+  /**
+   * Triggered when the Element fails to load.
+   */
+  onLoadError?: (event: {
+    elementType: 'linkAuthentication';
+    error: StripeError;
+  }) => any;
 }
 
 export type LinkAuthenticationElementComponent = FunctionComponent<
@@ -342,6 +351,11 @@ export interface PaymentElementProps extends ElementProps {
    * Triggered when the escape key is pressed within the Element.
    */
   onEscape?: () => any;
+
+  /**
+   * Triggered when the Element fails to load.
+   */
+  onLoadError?: (event: {elementType: 'payment'; error: StripeError}) => any;
 }
 
 export type PaymentElementComponent = FunctionComponent<PaymentElementProps>;
@@ -392,6 +406,14 @@ export interface ShippingAddressElementProps extends ElementProps {
    * Triggered when the escape key is pressed within the Element.
    */
   onEscape?: () => any;
+
+  /**
+   * Triggered when the Element fails to load.
+   */
+  onLoadError?: (event: {
+    elementType: 'shippingAddress';
+    error: StripeError;
+  }) => any;
 }
 
 export type ShippingAddressElementComponent = FunctionComponent<


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Add support for `onLoadError` convenience prop to the `loaderror` event.

This PR adds this prop to `payment`, `shippingAddress`, and `linkAuthentication` Elements.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Added unit test
