### PR TITLE
Add `onLoaderStart` prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-react": "^7.7.0",
     "@storybook/react": "^6.5.0-beta.8",
-    "@stripe/stripe-js": "^1.32.0",
+    "@stripe/stripe-js": "^1.34.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/react-hooks": "^8.0.0",
@@ -106,7 +106,7 @@
     "@types/react": "18.0.5"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": "^1.32.0",
+    "@stripe/stripe-js": "^1.34.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   }

--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -21,6 +21,7 @@ describe('createElementComponent', () => {
   let simulateReady: any;
   let simulateClick: any;
   let simulateLoadError: any;
+  let simulateLoaderStart: any;
 
   beforeEach(() => {
     mockStripe = mocks.mockStripe();
@@ -51,6 +52,9 @@ describe('createElementComponent', () => {
           break;
         case 'loaderror':
           simulateLoadError = fn;
+          break;
+        case 'loaderstart':
+          simulateLoaderStart = fn;
           break;
         default:
           throw new Error('TestSetupError: Unexpected event registration.');
@@ -371,6 +375,25 @@ describe('createElementComponent', () => {
       const loadErrorEventMock = Symbol('loaderror');
       simulateLoadError(loadErrorEventMock);
       expect(mockHandler2).toHaveBeenCalledWith(loadErrorEventMock);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    it('propagates the Element`s loaderstart event to the current onLoaderStart prop', () => {
+      const mockHandler = jest.fn();
+      const mockHandler2 = jest.fn();
+      const {rerender} = render(
+        <Elements stripe={mockStripe}>
+          <PaymentElement onLoaderStart={mockHandler} />
+        </Elements>
+      );
+      rerender(
+        <Elements stripe={mockStripe}>
+          <PaymentElement onLoaderStart={mockHandler2} />
+        </Elements>
+      );
+
+      simulateLoaderStart();
+      expect(mockHandler2).toHaveBeenCalledWith();
       expect(mockHandler).not.toHaveBeenCalled();
     });
 

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -27,6 +27,7 @@ interface PrivateElementProps {
   onReady?: UnknownCallback;
   onClick?: UnknownCallback;
   onLoadError?: UnknownCallback;
+  onLoaderStart?: UnknownCallback;
   options?: UnknownOptions;
 }
 
@@ -51,6 +52,7 @@ const createElementComponent = (
     onEscape = noop,
     onClick = noop,
     onLoadError = noop,
+    onLoaderStart = noop,
   }) => {
     const {elements} = useElementsContextWithUseCase(`mounts <${displayName}>`);
     const elementRef = React.useRef<stripeJs.StripeElement | null>(null);
@@ -63,6 +65,7 @@ const createElementComponent = (
     const callOnChange = useCallbackReference(onChange);
     const callOnEscape = useCallbackReference(onEscape);
     const callOnLoadError = useCallbackReference(onLoadError);
+    const callOnLoaderStart = useCallbackReference(onLoaderStart);
 
     React.useLayoutEffect(() => {
       if (elementRef.current == null && elements && domNode.current != null) {
@@ -79,6 +82,11 @@ const createElementComponent = (
         // just as they could listen for the `loaderror` event on any Element,
         // but only certain Elements will trigger the event.
         (element as any).on('loaderror', callOnLoadError);
+
+        // Users can pass an onLoaderStart prop on any Element component
+        // just as they could listen for the `loaderstart` event on any Element,
+        // but only certain Elements will trigger the event.
+        (element as any).on('loaderstart', callOnLoaderStart);
 
         // Users can pass an onClick prop on any Element component
         // just as they could listen for the `click` event on any Element,
@@ -133,6 +141,7 @@ const createElementComponent = (
     onReady: PropTypes.func,
     onClick: PropTypes.func,
     onLoadError: PropTypes.func,
+    onLoaderStart: PropTypes.func,
     options: PropTypes.object as any,
   };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -296,6 +296,11 @@ export interface LinkAuthenticationElementProps extends ElementProps {
     elementType: 'linkAuthentication';
     error: StripeError;
   }) => any;
+
+  /**
+   * Triggered when the [loader](https://stripe.com/docs/js/elements_object/create#stripe_elements-options-loader) UI is mounted to the DOM and ready to be displayed.
+   */
+  onLoaderStart?: (event: {elementType: 'linkAuthentication'}) => any;
 }
 
 export type LinkAuthenticationElementComponent = FunctionComponent<
@@ -356,6 +361,11 @@ export interface PaymentElementProps extends ElementProps {
    * Triggered when the Element fails to load.
    */
   onLoadError?: (event: {elementType: 'payment'; error: StripeError}) => any;
+
+  /**
+   * Triggered when the [loader](https://stripe.com/docs/js/elements_object/create#stripe_elements-options-loader) UI is mounted to the DOM and ready to be displayed.
+   */
+  onLoaderStart?: (event: {elementType: 'payment'}) => any;
 }
 
 export type PaymentElementComponent = FunctionComponent<PaymentElementProps>;
@@ -414,6 +424,11 @@ export interface ShippingAddressElementProps extends ElementProps {
     elementType: 'shippingAddress';
     error: StripeError;
   }) => any;
+
+  /**
+   * Triggered when the [loader](https://stripe.com/docs/js/elements_object/create#stripe_elements-options-loader) UI is mounted to the DOM and ready to be displayed.
+   */
+  onLoaderStart?: (event: {elementType: 'shippingAddress'}) => any;
 }
 
 export type ShippingAddressElementComponent = FunctionComponent<

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,10 +2130,10 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
-"@stripe/stripe-js@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.32.0.tgz#4ecdd298db61ad9b240622eafed58da974bd210e"
-  integrity sha512-7EvBnbBfS1aynfLRmBFcuumHNGjKxnNkO47rorFBktqDYHwo7Yw6pfDW2iqq0R8r7i7XiJEdWPvvEgQAiDrx3A==
+"@stripe/stripe-js@^1.34.0":
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.34.0.tgz#62fecff2580469ec56ec31066b73a0fc016749b8"
+  integrity sha512-fFuchE1mK2GWyZmTS87L6NaIvKo4yIj3SpkTuHY41A7frfB07/3z8l1jBrHKGzvVnlFkeCVnEvfMjBmdlqcO6w==
 
 "@testing-library/dom@^8.5.0":
   version "8.13.0"


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->
Add support for `onLoaderStart` convenience prop to the `loaderStart` event.

This PR adds this prop to `payment`, `shippingAddress`, and `linkAuthentication` Elements.


### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
Added test
