### PR TITLE
Add useCartElement and useCartElementState hooks

### DIFF
--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -27,7 +27,7 @@ const addDemo = (directory, file, stories) => {
 
 const hooksStories = storiesOf('react-stripe-js/Hooks', module);
 require
-  .context('../examples/hooks/', false, /\/\d-(.*).js$/)
+  .context('../examples/hooks/', false, /\/\d+-(.*).js$/)
   .keys()
   .forEach((key) => {
     addDemo('hooks', key.slice(2), hooksStories);
@@ -35,7 +35,7 @@ require
 
 const classStories = storiesOf('react-stripe-js/Class Components', module);
 require
-  .context('../examples/class-components/', false, /\/\d-(.*).js$/)
+  .context('../examples/class-components/', false, /\/\d+-(.*).js$/)
   .keys()
   .forEach((key) => {
     addDemo('class-components', key.slice(2), classStories);

--- a/examples/hooks/10-Cart.js
+++ b/examples/hooks/10-Cart.js
@@ -1,0 +1,128 @@
+// This example shows you how to set up React Stripe.js and use Elements.
+// Learn how to use the Cart Element to store your customers purchases using the official Stripe docs.
+// https://stripe.com/docs/elements/cart-element
+
+import React from 'react';
+import {loadStripe} from '@stripe/stripe-js';
+import {
+  CartElement,
+  Elements,
+  useCartElement,
+  useCartElementState,
+} from '../../src';
+
+import '../styles/common.css';
+
+const ProductPage = ({options}) => {
+  const cartElement = useCartElement();
+  const cartElementState = useCartElementState();
+  console.log('inside product page');
+
+  const handleCheckout = async (event) => {
+    console.log(event);
+    // Redirect to Checkout page
+    cartElement.cancelCheckout('Error message here');
+  };
+
+  const handleLineItemClick = async (event) => {
+    // Block native link redirect
+    event.preventDefault();
+    console.log(event.url);
+  };
+
+  const handleShow = () => {
+    cartElement.show();
+  };
+
+  const handleAddLineItem = () => {
+    cartElement.addLineItem({});
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={handleAddLineItem}>
+        Add line item
+      </button>
+      <button type="button" onClick={handleShow}>
+        View cart ({cartElementState?.lineItems?.count || 0})
+      </button>
+      <CartElement
+        options={options}
+        onCheckout={handleCheckout}
+        onLineItemClick={handleLineItemClick}
+      />
+    </div>
+  );
+};
+
+const THEMES = ['stripe', 'flat', 'none'];
+
+const App = () => {
+  const [pk, setPK] = React.useState(
+    window.sessionStorage.getItem('react-stripe-js-pk') || ''
+  );
+  const [clientSecret, setClientSecret] = React.useState('');
+  console.log('inside app');
+
+  React.useEffect(() => {
+    window.sessionStorage.setItem('react-stripe-js-pk', pk || '');
+  }, [pk]);
+
+  const [stripePromise, setStripePromise] = React.useState();
+  const [theme, setTheme] = React.useState('stripe');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setStripePromise(loadStripe(pk));
+  };
+
+  const handleThemeChange = (e) => {
+    setTheme(e.target.value);
+  };
+
+  const handleUnload = () => {
+    setStripePromise(null);
+    setClientSecret(null);
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Cart Session client_secret
+          <input
+            value={clientSecret}
+            onChange={(e) => setClientSecret(e.target.value)}
+          />
+        </label>
+        <label>
+          Publishable key{' '}
+          <input value={pk} onChange={(e) => setPK(e.target.value)} />
+        </label>
+        <button style={{marginRight: 10}} type="submit">
+          Load
+        </button>
+        <button type="button" onClick={handleUnload}>
+          Unload
+        </button>
+        <label>
+          Theme
+          <select onChange={handleThemeChange}>
+            {THEMES.map((val) => (
+              <option key={val} value={val}>
+                {val}
+              </option>
+            ))}
+          </select>
+        </label>
+      </form>
+      {stripePromise && clientSecret && (
+        <Elements stripe={stripePromise} options={{appearance: {theme}}}>
+          <ProductPage options={{clientSecret}} />
+        </Elements>
+      )}
+    </>
+  );
+};
+
+export default App;

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-react": "^7.7.0",
     "@storybook/react": "^6.5.0-beta.8",
-    "@stripe/stripe-js": "^1.38.1",
+    "@stripe/stripe-js": "^1.42.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/react-hooks": "^8.0.0",
@@ -106,7 +106,7 @@
     "@types/react": "18.0.5"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": "^1.41.0",
+    "@stripe/stripe-js": "^1.42.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   }

--- a/src/components/Elements.test.tsx
+++ b/src/components/Elements.test.tsx
@@ -10,15 +10,12 @@ import {
   useCartElement,
   useCartElementState,
 } from './Elements';
-import createElementComponent from './createElementComponent';
-import {CartElementComponent} from '../types';
 import * as mocks from '../../test/mocks';
 
 describe('Elements', () => {
   let mockStripe: any;
   let mockStripePromise: any;
   let mockElements: any;
-  let mockCartElement: any;
   let consoleError: any;
   let consoleWarn: any;
 
@@ -27,8 +24,6 @@ describe('Elements', () => {
     mockStripePromise = Promise.resolve(mockStripe);
     mockElements = mocks.mockElements();
     mockStripe.elements.mockReturnValue(mockElements);
-
-    mockCartElement = mocks.mockElement();
 
     jest.spyOn(console, 'error');
     jest.spyOn(console, 'warn');
@@ -73,42 +68,6 @@ describe('Elements', () => {
     const {result} = renderHook(() => useStripe(), {wrapper});
 
     expect(result.current).toBe(mockStripe);
-  });
-
-  test('injects cartElement with the useCartElement hook', () => {
-    const CartElement: CartElementComponent = createElementComponent(
-      'cart',
-      false
-    );
-
-    const wrapper = ({children}: any) => (
-      <Elements stripe={mockStripe}>
-        <CartElement options={{clientSecret: ''}} />
-        {children}
-      </Elements>
-    );
-
-    const {result} = renderHook(() => useCartElement(), {wrapper});
-
-    expect(result.current).toBe(mockCartElement);
-  });
-
-  test('returns cartElement state with the useCartElement hook', () => {
-    const CartElement: CartElementComponent = createElementComponent(
-      'cart',
-      false
-    );
-
-    const wrapper = ({children}: any) => (
-      <Elements stripe={mockStripe}>
-        <CartElement options={{clientSecret: ''}} />
-        {children}
-      </Elements>
-    );
-
-    const {result} = renderHook(() => useCartElementState(), {wrapper});
-
-    expect(result.current).toHaveProperty('lineItems.count');
   });
 
   test('provides elements and stripe with the ElementsConsumer component', () => {

--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -83,7 +83,7 @@ interface CartElementContextValue {
   ) => void;
 }
 
-export const CartElementContext = React.createContext<CartElementContextValue | null>(
+const CartElementContext = React.createContext<CartElementContextValue | null>(
   null
 );
 CartElementContext.displayName = 'CartElementContext';

--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -74,6 +74,33 @@ export const parseElementsContext = (
   return ctx;
 };
 
+interface CartElementContextValue {
+  cart: stripeJs.StripeCartElement | null;
+  cartState: stripeJs.StripeCartElementPayloadEvent | null;
+  setCart: (cart: stripeJs.StripeCartElement | null) => void;
+  setCartState: (
+    cartState: stripeJs.StripeCartElementPayloadEvent | null
+  ) => void;
+}
+
+export const CartElementContext = React.createContext<CartElementContextValue | null>(
+  null
+);
+CartElementContext.displayName = 'CartElementContext';
+
+export const parseCartElementContext = (
+  ctx: CartElementContextValue | null,
+  useCase: string
+): CartElementContextValue => {
+  if (!ctx) {
+    throw new Error(
+      `Could not find Elements context; You need to wrap the part of your app that ${useCase} in an <Elements> provider.`
+    );
+  }
+
+  return ctx;
+};
+
 interface ElementsProps {
   /**
    * A [Stripe object](https://stripe.com/docs/js/initializing) or a `Promise` resolving to a `Stripe` object.
@@ -115,6 +142,14 @@ export const Elements: FunctionComponent<PropsWithChildren<ElementsProps>> = (({
   const parsed = React.useMemo(() => parseStripeProp(rawStripeProp), [
     rawStripeProp,
   ]);
+
+  const [cart, setCart] = React.useState<stripeJs.StripeCartElement | null>(
+    null
+  );
+  const [
+    cartState,
+    setCartState,
+  ] = React.useState<stripeJs.StripeCartElementPayloadEvent | null>(null);
 
   // For a sync stripe instance, initialize into context
   const [ctx, setContext] = React.useState<ElementsContextValue>(() => ({
@@ -205,7 +240,13 @@ export const Elements: FunctionComponent<PropsWithChildren<ElementsProps>> = (({
   }, [ctx.stripe]);
 
   return (
-    <ElementsContext.Provider value={ctx}>{children}</ElementsContext.Provider>
+    <ElementsContext.Provider value={ctx}>
+      <CartElementContext.Provider
+        value={{cart, setCart, cartState, setCartState}}
+      >
+        {children}
+      </CartElementContext.Provider>
+    </ElementsContext.Provider>
   );
 }) as FunctionComponent<PropsWithChildren<ElementsProps>>;
 
@@ -219,6 +260,13 @@ export const useElementsContextWithUseCase = (
 ): ElementsContextValue => {
   const ctx = React.useContext(ElementsContext);
   return parseElementsContext(ctx, useCaseMessage);
+};
+
+export const useCartElementContextWithUseCase = (
+  useCaseMessage: string
+): CartElementContextValue => {
+  const ctx = React.useContext(CartElementContext);
+  return parseCartElementContext(ctx, useCaseMessage);
 };
 
 /**
@@ -235,6 +283,24 @@ export const useElements = (): stripeJs.StripeElements | null => {
 export const useStripe = (): stripeJs.Stripe | null => {
   const {stripe} = useElementsContextWithUseCase('calls useStripe()');
   return stripe;
+};
+
+/**
+ * @docs https://stripe.com/docs/payments/checkout/cart-element
+ */
+export const useCartElement = (): stripeJs.StripeCartElement | null => {
+  const {cart} = useCartElementContextWithUseCase('calls useCartElement()');
+  return cart;
+};
+
+/**
+ * @docs https://stripe.com/docs/payments/checkout/cart-element
+ */
+export const useCartElementState = (): stripeJs.StripeCartElementPayloadEvent | null => {
+  const {cartState} = useCartElementContextWithUseCase(
+    'calls useCartElementState()'
+  );
+  return cartState;
 };
 
 interface ElementsConsumerProps {

--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -286,7 +286,7 @@ describe('createElementComponent', () => {
       expect(mockHandler).not.toHaveBeenCalled();
     });
 
-    it('useCartElement', () => {
+    it('sets cart in the CartElementContext', () => {
       expect(mockCartElementContext.cart).toBe(null);
 
       render(
@@ -298,7 +298,7 @@ describe('createElementComponent', () => {
       expect(mockCartElementContext.cart).toBe(mockElement);
     });
 
-    it('useCartElementState', () => {
+    it('sets cartState in the CartElementContext', () => {
       render(
         <Elements stripe={mockStripe}>
           <CartElement />

--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -8,6 +8,7 @@ import {
   CardElementComponent,
   PaymentElementComponent,
   PaymentRequestButtonElementComponent,
+  CartElementComponent,
 } from '../types';
 
 describe('createElementComponent', () => {
@@ -23,6 +24,8 @@ describe('createElementComponent', () => {
   let simulateLoadError: any;
   let simulateLoaderStart: any;
   let simulateNetworksChange: any;
+  let simulateCheckout: any;
+  let simulateLineItemClick: any;
 
   beforeEach(() => {
     mockStripe = mocks.mockStripe();
@@ -59,6 +62,12 @@ describe('createElementComponent', () => {
           break;
         case 'networkschange':
           simulateNetworksChange = fn;
+          break;
+        case 'checkout':
+          simulateCheckout = fn;
+          break;
+        case 'lineitemclick':
+          simulateLineItemClick = fn;
           break;
         default:
           throw new Error('TestSetupError: Unexpected event registration.');
@@ -135,6 +144,11 @@ describe('createElementComponent', () => {
     );
     const PaymentElement: PaymentElementComponent = createElementComponent(
       'payment',
+      false
+    );
+
+    const CartElement: CartElementComponent = createElementComponent(
+      'cart',
       false
     );
 
@@ -417,6 +431,46 @@ describe('createElementComponent', () => {
 
       simulateNetworksChange();
       expect(mockHandler2).toHaveBeenCalledWith();
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    it('propagates the Element`s checkout event to the current onCheckout prop', () => {
+      const mockHandler = jest.fn();
+      const mockHandler2 = jest.fn();
+      const {rerender} = render(
+        <Elements stripe={mockStripe}>
+          <CartElement onCheckout={mockHandler} />
+        </Elements>
+      );
+      rerender(
+        <Elements stripe={mockStripe}>
+          <CartElement onCheckout={mockHandler2} />
+        </Elements>
+      );
+
+      const checkoutEventMock = Symbol('checkout');
+      simulateCheckout(checkoutEventMock);
+      expect(mockHandler2).toHaveBeenCalledWith(checkoutEventMock);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    it('propagates the Element`s lineitemclick event to the current onLineItemClick prop', () => {
+      const mockHandler = jest.fn();
+      const mockHandler2 = jest.fn();
+      const {rerender} = render(
+        <Elements stripe={mockStripe}>
+          <CartElement onLineItemClick={mockHandler} />
+        </Elements>
+      );
+      rerender(
+        <Elements stripe={mockStripe}>
+          <CartElement onLineItemClick={mockHandler2} />
+        </Elements>
+      );
+
+      const lineItemClickEventMock = Symbol('lineitemclick');
+      simulateLineItemClick(lineItemClickEventMock);
+      expect(mockHandler2).toHaveBeenCalledWith(lineItemClickEventMock);
       expect(mockHandler).not.toHaveBeenCalled();
     });
 

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
-import {useElementsContextWithUseCase} from './Elements';
+import {useElementsContextWithUseCase, CartElementContext} from './Elements';
 import {useCallbackReference} from '../utils/useCallbackReference';
 import {ElementProps} from '../types';
 import {usePrevious} from '../utils/usePrevious';
@@ -29,6 +29,8 @@ interface PrivateElementProps {
   onLoadError?: UnknownCallback;
   onLoaderStart?: UnknownCallback;
   onNetworksChange?: UnknownCallback;
+  onCheckout?: UnknownCallback;
+  onLineItemClick?: UnknownCallback;
   options?: UnknownOptions;
 }
 
@@ -55,10 +57,14 @@ const createElementComponent = (
     onLoadError = noop,
     onLoaderStart = noop,
     onNetworksChange = noop,
+    onCheckout = noop,
+    onLineItemClick = noop,
   }) => {
     const {elements} = useElementsContextWithUseCase(`mounts <${displayName}>`);
     const elementRef = React.useRef<stripeJs.StripeElement | null>(null);
     const domNode = React.useRef<HTMLDivElement | null>(null);
+
+    const {setCart, setCartState} = React.useContext(CartElementContext) || {};
 
     const callOnReady = useCallbackReference(onReady);
     const callOnBlur = useCallbackReference(onBlur);
@@ -69,17 +75,55 @@ const createElementComponent = (
     const callOnLoadError = useCallbackReference(onLoadError);
     const callOnLoaderStart = useCallbackReference(onLoaderStart);
     const callOnNetworksChange = useCallbackReference(onNetworksChange);
+    const callOnCheckout = useCallbackReference(onCheckout);
+    const callOnLineItemClick = useCallbackReference(onLineItemClick);
 
     React.useLayoutEffect(() => {
       if (elementRef.current == null && elements && domNode.current != null) {
         const element = elements.create(type as any, options);
+        if (type === 'cart' && setCart) {
+          // we know that elements.create return value must be of type StripeCartElement if type is 'cart',
+          // we need to cast because typescript is not able to infer which overloaded method is used based off param type
+          setCart((element as unknown) as stripeJs.StripeCartElement);
+        }
         elementRef.current = element;
         element.mount(domNode.current);
-        element.on('ready', () => callOnReady(element));
-        element.on('change', callOnChange);
-        element.on('blur', callOnBlur);
-        element.on('focus', callOnFocus);
-        element.on('escape', callOnEscape);
+        element.on('ready', (event) => {
+          if (type === 'cart' && setCartState) {
+            // we know that elements.on event must be of type StripeCartPayloadEvent if type is 'cart'
+            // we need to cast because typescript is not able to infer which overloaded method is used based off param type
+            setCartState(
+              (event as unknown) as stripeJs.StripeCartElementPayloadEvent
+            );
+          }
+          callOnReady(element);
+        });
+
+        element.on('change', (event) => {
+          if (type === 'cart' && setCartState) {
+            // we know that elements.on event must be of type StripeCartPayloadEvent if type is 'cart'
+            // we need to cast because typescript is not able to infer which overloaded method is used based off param type
+            setCartState(
+              (event as unknown) as stripeJs.StripeCartElementPayloadEvent
+            );
+          }
+          callOnChange(event);
+        });
+
+        // Users can pass an onLoadError prop on any Element component
+        // just as they could listen for the `blur` event on any Element,
+        // but only certain Elements will trigger the event.
+        (element as any).on('blur', callOnBlur);
+
+        // Users can pass an onLoadError prop on any Element component
+        // just as they could listen for the `focus` event on any Element,
+        // but only certain Elements will trigger the event.
+        (element as any).on('focus', callOnFocus);
+
+        // Users can pass an onLoadError prop on any Element component
+        // just as they could listen for the `escape` event on any Element,
+        // but only certain Elements will trigger the event.
+        (element as any).on('escape', callOnEscape);
 
         // Users can pass an onLoadError prop on any Element component
         // just as they could listen for the `loaderror` event on any Element,
@@ -100,6 +144,16 @@ const createElementComponent = (
         // just as they could listen for the `click` event on any Element,
         // but only the PaymentRequestButton will actually trigger the event.
         (element as any).on('click', callOnClick);
+
+        // Users can pass an onLoadError prop on any Element component
+        // just as they could listen for the `checkout` event on any Element,
+        // but only certain Elements will trigger the event.
+        (element as any).on('checkout', callOnCheckout);
+
+        // Users can pass an onLoadError prop on any Element component
+        // just as they could listen for the `lineitemclick` event on any Element,
+        // but only certain Elements will trigger the event.
+        (element as any).on('lineitemclick', callOnLineItemClick);
       }
     });
 
@@ -147,10 +201,13 @@ const createElementComponent = (
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,
     onReady: PropTypes.func,
+    onEscape: PropTypes.func,
     onClick: PropTypes.func,
     onLoadError: PropTypes.func,
     onLoaderStart: PropTypes.func,
     onNetworksChange: PropTypes.func,
+    onCheckout: PropTypes.func,
+    onLineItemClick: PropTypes.func,
     options: PropTypes.object as any,
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ export * from './types';
 export {
   useElements,
   useStripe,
+  useCartElement,
+  useCartElementState,
   Elements,
   ElementsConsumer,
 } from './components/Elements';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -172,7 +172,18 @@ export interface CardCvcElementProps extends ElementProps {
 
 export type CardCvcElementComponent = FunctionComponent<CardCvcElementProps>;
 
-export interface CartElementProps extends ElementProps {
+// CartElementProps does not extend ElementsProps because Cart Element does not have onBlur and onFocus events
+export interface CartElementProps {
+  /**
+   * Passes through to the [Element’s container](https://stripe.com/docs/js/element/the_element_container).
+   */
+  id?: string;
+
+  /**
+   * Passes through to the [Element’s container](https://stripe.com/docs/js/element/the_element_container).
+   */
+  className?: string;
+
   /**
    * An object containing [Element configuration options](https://stripe.com/docs/js/elements_object/create_cart_element#cart_element_create-options).
    */

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -30,3 +30,17 @@ export const mockStripe = () => ({
   registerAppInfo: jest.fn(),
   _registerWrapper: jest.fn(),
 });
+
+export const mockCartElementContext = () => {
+  const cartElementContext = {
+    cart: null,
+    cartState: null,
+  };
+  cartElementContext.setCart = (val) => {
+    cartElementContext.cart = val;
+  };
+  cartElementContext.setCartState = (val) => {
+    cartElementContext.cartState = val;
+  };
+  return cartElementContext;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,10 +2130,10 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
-"@stripe/stripe-js@^1.38.1":
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.41.0.tgz#986f3f222ba4466301f7809934afafafde9b28fd"
-  integrity sha512-9cbv1CO/fF37qDiHFCxkRgSJjlIZLV0bl+m6zu4dUObRnfYq5bpczCByOvhiSWtbrKqNhYL1j+otPSogRfSqGw==
+"@stripe/stripe-js@^1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.42.0.tgz#6074d0ac184bd70c9e5b5bc00e126719277e0128"
+  integrity sha512-ZaQpZo5PRv/mN6157OywMW4fc7FIS+eI/tS12I1gU9MdvnL8fzFktuAU/g9FyUOL22E4t9hF1tsfLQAZcQDokQ==
 
 "@testing-library/dom@^8.5.0":
   version "8.13.0"


### PR DESCRIPTION
### Summary & motivation

**useCartElement**
`useCartElement` is a react hook that retrieves the Cart Element, similar to the effect of calling `elements.getElement('cart')`. This hook exists so that React users can more easily call cart functions such as:
```
const cartElement = useCartElement();

cartElement.addLineItem({product: "prod_123"});
cartElement.show();
cartElement.hide();
cartElement.cancelCheckout("Checkout cancelled because...");
cartElement.update({ showOnAdd: false );
```

**useCartElementState**
`useCartElementState` is a react hook that retrieves the last value returned by the `ready` or `change` events (or null if no event has occurred yet). This value is used to display the cart count in the merchant's UI. The value returned has the shape:
```
{
  id: "cart_session_123",
  elementType: 'cart',
  lineItems: {
    count: 1,
  }
}
```

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

Wrote unit tests, and a ran a storybook scenario to confirm it works

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
