### PR TITLE
Updated cart ready event to return event instead of element

### DIFF
--- a/examples/hooks/10-Cart.js
+++ b/examples/hooks/10-Cart.js
@@ -17,6 +17,11 @@ const ProductPage = ({options, productId}) => {
   const cartElement = useCartElement();
   const cartElementState = useCartElementState();
 
+  const handleReady = async (event) => {
+    if (!cartElement) return;
+    console.log(event?.lineItems?.count);
+  };
+
   const handleCheckout = async () => {
     if (!cartElement) return;
     // Redirect to Checkout page
@@ -50,6 +55,7 @@ const ProductPage = ({options, productId}) => {
       </button>
       <CartElement
         options={options}
+        onReady={handleReady}
         onCheckout={handleCheckout}
         onLineItemClick={handleLineItemClick}
       />

--- a/examples/hooks/10-Cart.js
+++ b/examples/hooks/10-Cart.js
@@ -17,20 +17,23 @@ const ProductPage = ({options, productId}) => {
   const cartElement = useCartElement();
   const cartElementState = useCartElementState();
 
-  const handleReady = async (event) => {
-    if (!cartElement) return;
+  const handleReady = (event) => {
     console.log(event?.lineItems?.count);
   };
 
-  const handleCheckout = async () => {
+  const handleChange = (event) => {
+    console.log(event?.lineItems?.count);
+  };
+
+  const handleCheckout = (event) => {
+    console.log(event);
     if (!cartElement) return;
-    // Redirect to Checkout page
+    // redirect to Checkout page would go here
     cartElement.cancelCheckout('Error message here');
   };
 
-  const handleLineItemClick = async (event) => {
-    if (!cartElement) return;
-    // Block native link redirect
+  const handleLineItemClick = (event) => {
+    // calling preventDefault blocks native link redirect
     event.preventDefault();
     console.log(event.url);
   };
@@ -56,6 +59,7 @@ const ProductPage = ({options, productId}) => {
       <CartElement
         options={options}
         onReady={handleReady}
+        onChange={handleChange}
         onCheckout={handleCheckout}
         onLineItemClick={handleLineItemClick}
       />

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -94,14 +94,19 @@ const createElementComponent = (
         elementRef.current = element;
         element.mount(domNode.current);
         element.on('ready', (event) => {
-          if (type === 'cart' && setCartState) {
+          if (type === 'cart') {
             // we know that elements.on event must be of type StripeCartPayloadEvent if type is 'cart'
             // we need to cast because typescript is not able to infer which overloaded method is used based off param type
-            setCartState(
-              (event as unknown) as stripeJs.StripeCartElementPayloadEvent
-            );
+            if (setCartState) {
+              setCartState(
+                (event as unknown) as stripeJs.StripeCartElementPayloadEvent
+              );
+            }
+            // the cart ready event returns a CartStatePayload instead of the CartElement
+            callOnReady(event);
+          } else {
+            callOnReady(element);
           }
-          callOnReady(element);
         });
 
         element.on('change', (event) => {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Changes the onReady event handler for cart to return the event instead of the element. Returning the element is correct behavior for other elements, but the cart element needs to return the event instead.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Updated and ran storybook
