### PR TITLE
Card number should be visible

### DIFF
--- a/examples/hooks/1-Card-Detailed.js
+++ b/examples/hooks/1-Card-Detailed.js
@@ -14,7 +14,7 @@ const CARD_OPTIONS = {
   style: {
     base: {
       iconColor: '#c4f0ff',
-      color: '#fff',
+      color: '#000',
       fontWeight: 500,
       fontFamily: 'Roboto, Open Sans, Segoe UI, sans-serif',
       fontSize: '16px',


### PR DESCRIPTION
### Summary & motivation

The `React Hooks Card Detailed` sample code currently sets the foreground color for the card to white. Setting the foreground color to white on a white background field makes it impossible to see the card number when entering it in the form. 

The correct foreground color value to use with the sample code is a dark color like black.

