### PR TITLE
Do not run the "publishing release" script silently

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -131,7 +131,7 @@ echo "Building"
 yarn -s run build
 
 echo "Publishing release"
-yarn -s --ignore-scripts publish --non-interactive --access=public
+yarn --ignore-scripts publish --non-interactive --access=public
 
 echo "Pushing git commit and tag"
 git push --follow-tags


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Depending on one's 2FA settings with npm, the script may console output a link you need to go to to perform the auth. When the script runs with `-s`, you can't click on that link.

As a fix, this removes the `-s` flag.

### API review

<!-- Delete this section if this change involves no API changes. -->

Copy [this template] **or** link to an API review issue.

[this template]:
  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

Ran the command without `-s` to publish the latest version :)

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
