### PR TITLE
Patch/Fixed CVE-2021-3777: tmpl vulnerable to Inefficient Regular Expression Complexity

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11490,9 +11490,9 @@ tmp@^0.0.33:
     os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
-  integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
+  integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Summary & motivation
nodejs-tmpl is simple string formatting. tmpl is vulnerable to Inefficient Regular Expression Complexity which may lead to resource exhaustion. Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process. The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your server down.

```js
var tmpl = require("tmpl") for(var i = 1; i <= 1000; i++){
   "var time = Date.now(); payload =""hello, ""+""{".repeat(i*10000) +"day""tmpl(payload",
   {
      "day":"tomorrow"
   }") var time_taken = Date.now() - time; console.log(""payload length: ""+ payload.length +"" - time taken: ""+ time_taken +""ms"")"
}
```
The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.
Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as catastrophic backtracking.


[CVE-2021-3777](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3777) [CWE-400](https://cwe.mitre.org/data/definitions/400.html) 
`CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`
