### PR TITLE
Switch back to a ref to track element creating, updating, and destroying

### DIFF
--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -209,6 +209,34 @@ describe('createElementComponent', () => {
       expect(simulateOff).not.toBeCalled();
     });
 
+    it('creates, destroys, then re-creates element in strict mode', () => {
+      expect.assertions(4);
+
+      let elementCreated = false;
+
+      mockElements.create.mockImplementation(() => {
+        expect(elementCreated).toBe(false);
+        elementCreated = true;
+
+        return mockElement;
+      });
+
+      mockElement.destroy.mockImplementation(() => {
+        elementCreated = false;
+      });
+
+      render(
+        <StrictMode>
+          <Elements stripe={mockStripe}>
+            <CardElement />
+          </Elements>
+        </StrictMode>
+      );
+
+      expect(mockElements.create).toHaveBeenCalledTimes(2);
+      expect(mockElement.destroy).toHaveBeenCalledTimes(1);
+    });
+
     it('mounts the element', () => {
       const {container} = render(
         <Elements stripe={mockStripe}>

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -147,7 +147,9 @@ const createElementComponent = (
           setCart((newElement as unknown) as stripeJs.StripeCartElement);
         }
 
+        // Store element in a ref to ensure it's _immediately_ available in cleanup hooks in StrictMode
         elementRef.current = newElement;
+        // Store element in state to to facilitate event listener attachment
         setElement(newElement);
 
         newElement.mount(domNode.current);

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -73,6 +73,7 @@ const createElementComponent = (
     const [element, setElement] = React.useState<stripeJs.StripeElement | null>(
       null
     );
+    const elementRef = React.useRef<stripeJs.StripeElement | null>(null);
     const domNode = React.useRef<HTMLDivElement | null>(null);
 
     const {setCart, setCartState} = useCartElementContextWithUseCase(
@@ -138,21 +139,24 @@ const createElementComponent = (
     useAttachEvent(element, 'checkout', checkoutCallback);
 
     React.useLayoutEffect(() => {
-      if (element === null && elements && domNode.current !== null) {
+      if (elementRef.current === null && elements && domNode.current !== null) {
         const newElement = elements.create(type as any, options);
         if (type === 'cart' && setCart) {
           // we know that elements.create return value must be of type StripeCartElement if type is 'cart',
           // we need to cast because typescript is not able to infer which overloaded method is used based off param type
           setCart((newElement as unknown) as stripeJs.StripeCartElement);
         }
+
+        elementRef.current = newElement;
         setElement(newElement);
+
         newElement.mount(domNode.current);
       }
-    }, [element, elements, options, setCart]);
+    }, [elements, options, setCart]);
 
     const prevOptions = usePrevious(options);
     React.useEffect(() => {
-      if (!element) {
+      if (!elementRef.current) {
         return;
       }
 
@@ -161,17 +165,18 @@ const createElementComponent = (
       ]);
 
       if (updates) {
-        element.update(updates);
+        elementRef.current.update(updates);
       }
-    }, [options, prevOptions, element]);
+    }, [options, prevOptions]);
 
     React.useLayoutEffect(() => {
       return () => {
-        if (element) {
-          element.destroy();
+        if (elementRef.current) {
+          elementRef.current.destroy();
+          elementRef.current = null;
         }
       };
-    }, [element]);
+    }, []);
 
     return <div id={id} className={className} ref={domNode} />;
   };

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -149,7 +149,7 @@ const createElementComponent = (
 
         // Store element in a ref to ensure it's _immediately_ available in cleanup hooks in StrictMode
         elementRef.current = newElement;
-        // Store element in state to to facilitate event listener attachment
+        // Store element in state to facilitate event listener attachment
         setElement(newElement);
 
         newElement.mount(domNode.current);


### PR DESCRIPTION
### Summary & motivation

Addresses #375: if un-mounting occurs on the same render as creating the element (ex. in strictmode), `elements.create` could get called multiple times without `element.destroy` being called. This was because setting our state with `setElement` doesn't apply to the next render, so the `element` would still be null and we wouldn't call to destroy.

This PR reverts part of #372 by switching back to a ref to track creating, updating, and destroying an element. However, it keeps the `element` state used to attach events in that PR.

### Testing & documentation

- Added unit test that fails in v1.16.3 for strict mode to make sure .create() and destroy() get called correctly
- Tested against [reproduction](https://glitch.com/edit/#!/boundless-goofy-tanker?path=src%2Findex.jsx%3A18%3A8) of the issue, where multiple re-renders using React 17 (not in strict mode) threw an error.
- Storybooks for Payment and Card Element still both work