### PR TITLE
Wraps component destructor in a trycatch

### DIFF
--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -173,9 +173,16 @@ const createElementComponent = (
 
     React.useLayoutEffect(() => {
       return () => {
-        if (elementRef.current) {
-          elementRef.current.destroy();
-          elementRef.current = null;
+        try {
+          if (
+            elementRef.current &&
+            typeof elementRef.current.destroy === 'function'
+          ) {
+            elementRef.current.destroy();
+            elementRef.current = null;
+          }
+        } catch (error) {
+          console.warn('threw an error while destroying', error);
         }
       };
     }, []);

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -182,7 +182,7 @@ const createElementComponent = (
             elementRef.current = null;
           }
         } catch (error) {
-          console.warn('threw an error while destroying', error);
+          // Do nothing
         }
       };
     }, []);

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -173,16 +173,16 @@ const createElementComponent = (
 
     React.useLayoutEffect(() => {
       return () => {
-        try {
-          if (
-            elementRef.current &&
-            typeof elementRef.current.destroy === 'function'
-          ) {
+        if (
+          elementRef.current &&
+          typeof elementRef.current.destroy === 'function'
+        ) {
+          try {
             elementRef.current.destroy();
             elementRef.current = null;
+          } catch (error) {
+            // Do nothing
           }
-        } catch (error) {
-          // Do nothing
         }
       };
     }, []);


### PR DESCRIPTION
### Summary & motivation

When the Payment Element destroys itself, React doesn't always know about it. So when React attempts to unmount the a destroyed PE, an integration error is thrown and the application crashes.

One reproducible scenario of this is when creating a PE with an `amount` that is too small. The call to elements/session returns an error like this:

```
No valid payment method types for this configuration. Please ensure that you have activated payment methods compatible with your chosen currency in your dashboard (https://dashboard.stripe.com/settings/payment_methods) and that the `amount` (30) is not lower than the `currency` (usd) minimum: https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
```

Then the `loaderror` event is triggered. (I believe the component self-destructs in stripe-js, but React still has a reference to it.) So if the merchant attempts to unmount the PE or a wrapper around the PE, the app crashes because it tries to call `destroy()` on a component that isn't there.

**The solution (at least for now)**
Wrap the `destroy()` call in a trycatch, so that it doesn't crash the app.

### Testing & documentation

Manually validated the change. Existing tests continue to pass.
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
