### PR TITLE
Add preid support in publish script

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -4,15 +4,18 @@ set -euo pipefail
 IFS=$'\n\t'
 
 RELEASE_TYPE=${1:-}
+PREID=${2:-}
 
 echo_help() {
   cat << EOF
 USAGE:
-    ./scripts/publish <release_type>
+    ./scripts/publish <release_type> <pre_id>
 
 ARGS:
     <release_type>
             A Semantic Versioning release type used to bump the version number. Either "patch", "minor", "major", "prepatch", "preminor", "premajor", or "prerelease".
+    <pre_id>
+            Adds an identifier to be used to prefix premajor, preminor, prepatch or prerelease version increments. Either "alpha" or "beta".
 EOF
 }
 
@@ -105,6 +108,24 @@ case $RELEASE_TYPE in
     ;;
 esac
 
+# validate preid if passed
+ALLOWED_PRERELEASE_TYPES=(prepatch preminor premajor prerelease)
+if [ -n "$PREID" ]; then
+    if [ "$PREID" != "alpha" ] && [ "$PREID" != "beta" ]; then
+        echo "Invalid pre_id. It should be either 'alpha' or 'beta'"
+        echo ""
+        echo_help
+        exit 1
+    fi
+    if [ -n "$RELEASE_TYPE" ] && [[ ! " ${ALLOWED_PRERELEASE_TYPES[*]} " =~ "${RELEASE_TYPE}" ]]; then
+        ALLOWED_PRERELEASE_TYPES_STRING=$(printf "'%s', " "${ALLOWED_PRERELEASE_TYPES[@]}")
+        echo "Invalid release_type. It should be one of: $ALLOWED_PRERELEASE_TYPES_STRING when pre_id is set"
+        echo ""
+        echo_help
+        exit 1
+    fi
+fi
+
 # Make sure our working dir is the repo root directory
 cd "$(git rev-parse --show-toplevel)"
 
@@ -134,8 +155,14 @@ yarn -s install --frozen-lockfile
 echo "Running tests"
 yarn -s run test
 
-echo "Bumping package.json $RELEASE_TYPE version and tagging commit"
-yarn -s version --$RELEASE_TYPE
+if [ -n "$PREID" ]; then
+  echo "Bumping package.json $RELEASE_TYPE, $PREID version and tagging commit"
+  yarn -s version --$RELEASE_TYPE --preid $PREID
+else
+  echo "Bumping package.json $RELEASE_TYPE version and tagging commit"
+  yarn -s version --$RELEASE_TYPE
+fi
+
 
 create_github_release
 verify_commit_is_signed


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->
Add preid support in publish script

### API review

<!-- Delete this section if this change involves no API changes. -->

Copy [this template] **or** link to an API review issue.

[this template]:
  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
```shell
❯ ./scripts/publish -h        
USAGE:
    ./scripts/publish <release_type> <pre_id>

ARGS:
    <release_type>
            A Semantic Versioning release type used to bump the version number. Either "patch", "minor", "major", "prepatch", "preminor", "premajor", or "prerelease".
    <pre_id>
            Adds an identifier to be used to prefix premajor, preminor, prepatch or prerelease version increments. Either "alpha" or "beta".

❯ ./scripts/publish patch beta
Invalid RELEASE_TYPE. It should be one of: 'prepatch', 'preminor', 'premajor', 'prerelease',  when PREID is set

USAGE:
    ./scripts/publish <release_type> <pre_id>

ARGS:
    <release_type>
            A Semantic Versioning release type used to bump the version number. Either "patch", "minor", "major", "prepatch", "preminor", "premajor", or "prerelease".
    <pre_id>
            Adds an identifier to be used to prefix premajor, preminor, prepatch or prerelease version increments. Either "alpha" or "beta".

❯ ./scripts/publish minor beta
Invalid RELEASE_TYPE. It should be one of: 'prepatch', 'preminor', 'premajor', 'prerelease',  when PREID is set

USAGE:
    ./scripts/publish <release_type> <pre_id>

ARGS:
    <release_type>
            A Semantic Versioning release type used to bump the version number. Either "patch", "minor", "major", "prepatch", "preminor", "premajor", or "prerelease".
    <pre_id>
            Adds an identifier to be used to prefix premajor, preminor, prepatch or prerelease version increments. Either "alpha" or "beta".

❯ ./scripts/publish prerelease delta
Invalid PREID. It should be either 'alpha' or 'beta'

USAGE:
    ./scripts/publish <release_type> <pre_id>

ARGS:
    <release_type>
            A Semantic Versioning release type used to bump the version number. Either "patch", "minor", "major", "prepatch", "preminor", "premajor", or "prerelease".
    <pre_id>
            Adds an identifier to be used to prefix premajor, preminor, prepatch or prerelease version increments. Either "alpha" or "beta".

❯ yarn version --prerelease --preid alpha
yarn version v1.22.19
info Current version: 2.1.2
info New version: 2.1.3-alpha.0
✨  Done in 0.70s.
```