### PR TITLE
Fix publish script

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -111,19 +111,31 @@ esac
 # validate preid if passed
 ALLOWED_PRERELEASE_TYPES=(prepatch preminor premajor prerelease)
 if [ -n "$PREID" ]; then
-    if [ "$PREID" != "alpha" ] && [ "$PREID" != "beta" ]; then
-        echo "Invalid pre_id. It should be either 'alpha' or 'beta'"
-        echo ""
-        echo_help
-        exit 1
+  if [ "$PREID" != "alpha" ] && [ "$PREID" != "beta" ]; then
+    echo "Invalid pre_id. It should be either 'alpha' or 'beta'"
+    echo ""
+    echo_help
+    exit 1
+  fi
+
+  if [ -n "$RELEASE_TYPE" ]; then
+    valid=false
+
+    for type in "${ALLOWED_PRERELEASE_TYPES[@]}"; do
+      if [ "$type" = "$RELEASE_TYPE" ]; then
+        valid=true
+        break
+      fi
+    done
+
+    if [ "$valid" = false ]; then
+      ALLOWED_PRERELEASE_TYPES_STRING=$(printf "'%s', " "${ALLOWED_PRERELEASE_TYPES[@]}")
+      echo "Invalid release_type. It should be one of: $ALLOWED_PRERELEASE_TYPES_STRING when pre_id is set"
+      echo ""
+      echo_help
+      exit 1
     fi
-    if [ -n "$RELEASE_TYPE" ] && [[ ! " ${ALLOWED_PRERELEASE_TYPES[*]} " =~ "${RELEASE_TYPE}" ]]; then
-        ALLOWED_PRERELEASE_TYPES_STRING=$(printf "'%s', " "${ALLOWED_PRERELEASE_TYPES[@]}")
-        echo "Invalid release_type. It should be one of: $ALLOWED_PRERELEASE_TYPES_STRING when pre_id is set"
-        echo ""
-        echo_help
-        exit 1
-    fi
+  fi
 fi
 
 # Make sure our working dir is the repo root directory


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Fix publish script. The regex comparison failed when release_type is `patch` because it sub-match `prepatch`.
Replace the logic to NOT use the 🙈 regex and use plain for-loop comparison. 😌 (❤️  Bash script!)

### API review

<!-- Delete this section if this change involves no API changes. -->

Copy [this template] **or** link to an API review issue.

[this template]:
  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

1. validation on preid
```shell
❯ ./scripts/publish patch x                   
Invalid pre_id. It should be either 'alpha' or 'beta'

USAGE:
    ./scripts/publish <release_type> <pre_id>

ARGS:
    <release_type>
            A Semantic Versioning release type used to bump the version number. Either "patch", "minor", "major", "prepatch", "preminor", "premajor", or "prerelease".
    <pre_id>
            Adds an identifier to be used to prefix premajor, preminor, prepatch or prerelease version increments. Either "alpha" or "beta".
```

2. test patch
```shell
❯ ./scripts/publish patch alpha               
Invalid release_type. It should be one of: 'prepatch', 'preminor', 'premajor', 'prerelease',  when pre_id is set

USAGE:
    ./scripts/publish <release_type> <pre_id>

ARGS:
    <release_type>
            A Semantic Versioning release type used to bump the version number. Either "patch", "minor", "major", "prepatch", "preminor", "premajor", or "prerelease".
    <pre_id>
            Adds an identifier to be used to prefix premajor, preminor, prepatch or prerelease version increments. Either "alpha" or "beta".
```

3. test minor
```
❯ ./scripts/publish minor alpha
Invalid release_type. It should be one of: 'prepatch', 'preminor', 'premajor', 'prerelease',  when pre_id is set

USAGE:
    ./scripts/publish <release_type> <pre_id>

ARGS:
    <release_type>
            A Semantic Versioning release type used to bump the version number. Either "patch", "minor", "major", "prepatch", "preminor", "premajor", or "prerelease".
    <pre_id>
            Adds an identifier to be used to prefix premajor, preminor, prepatch or prerelease version increments. Either "alpha" or "beta".
```

4. test major
```
❯ ./scripts/publish major alpha
Invalid release_type. It should be one of: 'prepatch', 'preminor', 'premajor', 'prerelease',  when pre_id is set

USAGE:
    ./scripts/publish <release_type> <pre_id>

ARGS:
    <release_type>
            A Semantic Versioning release type used to bump the version number. Either "patch", "minor", "major", "prepatch", "preminor", "premajor", or "prerelease".
    <pre_id>
            Adds an identifier to be used to prefix premajor, preminor, prepatch or prerelease version increments. Either "alpha" or "beta".
```