### PR TITLE
Add CustomCheckoutProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ es
 lib
 *.log
 .vim
+.vscode/

--- a/examples/hooks/11-Custom-Checkout.js
+++ b/examples/hooks/11-Custom-Checkout.js
@@ -91,10 +91,6 @@ const CheckoutForm = () => {
   const buttonDisabled =
     !stripe || !customCheckout || !customCheckout.canConfirm || loading;
 
-  if (!customCheckout) {
-    return null;
-  }
-
   return (
     <form onSubmit={handleSubmit}>
       <CustomerDetails />

--- a/examples/hooks/11-Custom-Checkout.js
+++ b/examples/hooks/11-Custom-Checkout.js
@@ -1,0 +1,189 @@
+import React from 'react';
+import {loadStripe} from '@stripe/stripe-js';
+import {
+  PaymentElement,
+  useStripe,
+  CustomCheckoutProvider,
+  useCustomCheckout,
+  AddressElement,
+} from '../../src';
+
+import '../styles/common.css';
+
+const CustomerDetails = () => {
+  const {
+    phoneNumber,
+    updatePhoneNumber,
+    email,
+    updateEmail,
+  } = useCustomCheckout();
+
+  const handlePhoneNumberChange = (event) => {
+    updatePhoneNumber(event.target.value);
+  };
+
+  const handleEmailChange = (event) => {
+    updateEmail(event.target.value);
+  };
+
+  return (
+    <div>
+      <h3>Customer Details</h3>
+      <label htmlFor="phoneNumber">Phone Number</label>
+      <input
+        id="phoneNumber"
+        name="phoneNumber"
+        type="text"
+        autoComplete="off"
+        onChange={handlePhoneNumberChange}
+        value={phoneNumber || ''}
+      />
+      <label htmlFor="email">Email</label>
+      <input
+        id="email"
+        name="email"
+        type="email"
+        autoComplete="email"
+        onChange={handleEmailChange}
+        value={email || ''}
+      />
+    </div>
+  );
+};
+
+const CheckoutForm = () => {
+  const customCheckout = useCustomCheckout();
+  const [status, setStatus] = React.useState();
+  const [loading, setLoading] = React.useState(false);
+  const stripe = useStripe();
+
+  React.useEffect(() => {
+    const {confirmationRequirements} = customCheckout || {};
+    setStatus(
+      confirmationRequirements && confirmationRequirements.length > 0
+        ? `Missing: ${confirmationRequirements.join(', ')}`
+        : ''
+    );
+  }, [customCheckout, setStatus]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (!stripe || !customCheckout) {
+      return;
+    }
+
+    const {canConfirm, confirm} = customCheckout;
+    if (!canConfirm) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await confirm({return_url: window.location.href});
+      setLoading(false);
+    } catch (err) {
+      console.error(err);
+      setStatus(err.message);
+    }
+  };
+
+  const buttonDisabled =
+    !stripe || !customCheckout || !customCheckout.canConfirm || loading;
+
+  if (!customCheckout) {
+    return null;
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <CustomerDetails />
+      <h3>Payment Dettails</h3>
+      <PaymentElement />
+      <h3>Billing Details</h3>
+      <AddressElement options={{mode: 'billing'}} />
+      <button type="submit" disabled={buttonDisabled}>
+        {loading ? 'Processing...' : 'Pay'}
+      </button>
+      {status && <p>{status}</p>}
+    </form>
+  );
+};
+
+const THEMES = ['stripe', 'flat', 'night'];
+
+const App = () => {
+  const [pk, setPK] = React.useState(
+    window.sessionStorage.getItem('react-stripe-js-pk') || ''
+  );
+  const [clientSecret, setClientSecret] = React.useState('');
+
+  React.useEffect(() => {
+    window.sessionStorage.setItem('react-stripe-js-pk', pk || '');
+  }, [pk]);
+
+  const [stripePromise, setStripePromise] = React.useState();
+  const [theme, setTheme] = React.useState('stripe');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setStripePromise(
+      loadStripe(pk, {
+        betas: ['custom_checkout_beta_1'],
+      })
+    );
+  };
+
+  const handleThemeChange = (e) => {
+    setTheme(e.target.value);
+  };
+
+  const handleUnload = () => {
+    setStripePromise(null);
+    setClientSecret(null);
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSubmit}>
+        <label>
+          CheckoutSession client_secret
+          <input
+            value={clientSecret}
+            onChange={(e) => setClientSecret(e.target.value)}
+          />
+        </label>
+        <label>
+          Publishable key{' '}
+          <input value={pk} onChange={(e) => setPK(e.target.value)} />
+        </label>
+        <button style={{marginRight: 10}} type="submit">
+          Load
+        </button>
+        <button type="button" onClick={handleUnload}>
+          Unload
+        </button>
+        <label>
+          Theme
+          <select onChange={handleThemeChange}>
+            {THEMES.map((val) => (
+              <option key={val} value={val}>
+                {val}
+              </option>
+            ))}
+          </select>
+        </label>
+      </form>
+      {stripePromise && clientSecret && (
+        <CustomCheckoutProvider
+          stripe={stripePromise}
+          options={{clientSecret, elementsOptions: {appearance: {theme}}}}
+        >
+          <CheckoutForm />
+        </CustomCheckoutProvider>
+      )}
+    </>
+  );
+};
+
+export default App;

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-react": "^7.7.0",
     "@storybook/react": "^6.5.0-beta.8",
-    "@stripe/stripe-js": "^2.0.0",
+    "@stripe/stripe-js": "2.1.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/react-hooks": "^8.0.0",

--- a/src/components/CustomCheckout.test.tsx
+++ b/src/components/CustomCheckout.test.tsx
@@ -399,7 +399,7 @@ describe('CustomCheckoutProvider', () => {
   });
 
   describe('React.StrictMode', () => {
-    test('initCustomCheckout twice in StrictMode', async () => {
+    test('initCustomCheckout once in StrictMode', async () => {
       const TestComponent = () => {
         const _ = useCustomCheckout();
         return <div />;
@@ -419,7 +419,7 @@ describe('CustomCheckoutProvider', () => {
       });
 
       await waitFor(() =>
-        expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(2)
+        expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(1)
       );
     });
 
@@ -447,7 +447,7 @@ describe('CustomCheckoutProvider', () => {
       );
     });
 
-    test('allows changes to options via elements.update after setting the Stripe object in StrictMode', async () => {
+    test('allows changes to options via (mockCustomCheckoutSdk.changeAppearance after setting the Stripe object in StrictMode', async () => {
       let result: any;
       act(() => {
         result = render(
@@ -466,7 +466,7 @@ describe('CustomCheckoutProvider', () => {
       });
 
       await waitFor(() => {
-        expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(2);
+        expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(1);
         expect(mockStripe.initCustomCheckout).toHaveBeenCalledWith({
           clientSecret: 'cs_123',
           elementsOptions: {

--- a/src/components/CustomCheckout.test.tsx
+++ b/src/components/CustomCheckout.test.tsx
@@ -1,0 +1,456 @@
+import React, {StrictMode} from 'react';
+import {render, act, waitFor} from '@testing-library/react';
+import {renderHook} from '@testing-library/react-hooks';
+
+import {CustomCheckoutProvider, useCustomCheckout} from './CustomCheckout';
+import {useStripe} from './CustomCheckout';
+import * as mocks from '../../test/mocks';
+
+describe('CustomCheckoutProvider', () => {
+  let mockStripe: any;
+  let mockStripePromise: any;
+  let mockCustomCheckoutSdk: any;
+  let mockSession: any;
+  let consoleError: any;
+  let consoleWarn: any;
+  let mockCustomCheckout: any;
+
+  beforeEach(() => {
+    mockStripe = mocks.mockStripe();
+    mockStripePromise = Promise.resolve(mockStripe);
+    mockCustomCheckoutSdk = mocks.mockCustomCheckoutSdk();
+    mockStripe.initCustomCheckout.mockResolvedValue(mockCustomCheckoutSdk);
+    mockSession = mocks.mockCustomCheckoutSession();
+    mockCustomCheckoutSdk.session.mockReturnValue(mockSession);
+
+    const {on: _on, session: _session, ...actions} = mockCustomCheckoutSdk;
+
+    mockCustomCheckout = {...actions, ...mockSession};
+
+    jest.spyOn(console, 'error');
+    jest.spyOn(console, 'warn');
+    consoleError = console.error;
+    consoleWarn = console.warn;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('injects CustomCheckoutProvider with the useCustomCheckout hook', async () => {
+    const wrapper = ({children}: any) => (
+      <CustomCheckoutProvider
+        stripe={mockStripe}
+        options={{clientSecret: 'cs_123'}}
+      >
+        {children}
+      </CustomCheckoutProvider>
+    );
+
+    const {result, waitForNextUpdate} = renderHook(() => useCustomCheckout(), {
+      wrapper,
+    });
+
+    // observe intermediate states
+    await waitForNextUpdate();
+
+    // wait for all (potentially multiple) updates to finish
+    await waitFor(() => expect(result.current).toEqual(mockCustomCheckout));
+  });
+
+  test('injects CustomCheckoutProvider with the useStripe hook', async () => {
+    const wrapper = ({children}: any) => (
+      <CustomCheckoutProvider
+        stripe={mockStripe}
+        options={{clientSecret: 'cs_123'}}
+      >
+        {children}
+      </CustomCheckoutProvider>
+    );
+
+    const {result, waitForNextUpdate} = renderHook(() => useStripe(), {
+      wrapper,
+    });
+
+    // observe intermediate states
+    await waitForNextUpdate();
+
+    // wait for all (potentially multiple) updates to finish
+    await waitFor(() => expect(result.current).toBe(mockStripe));
+  });
+
+  test('allows a transition from null to a valid Stripe object', async () => {
+    let stripeProp: any = null;
+    const wrapper = ({children}: any) => (
+      <CustomCheckoutProvider
+        stripe={stripeProp}
+        options={{clientSecret: 'cs_123'}}
+      >
+        {children}
+      </CustomCheckoutProvider>
+    );
+
+    const {result, rerender} = renderHook(() => useCustomCheckout(), {wrapper});
+    expect(result.current).toBe(null);
+
+    stripeProp = mockStripe;
+    act(() => rerender());
+    await waitFor(() => expect(result.current).toEqual(mockCustomCheckout));
+  });
+
+  test('works with a Promise resolving to a valid Stripe object', async () => {
+    const wrapper = ({children}: any) => (
+      <CustomCheckoutProvider
+        stripe={mockStripePromise}
+        options={{clientSecret: 'cs_123'}}
+      >
+        {children}
+      </CustomCheckoutProvider>
+    );
+
+    const {result, waitForNextUpdate} = renderHook(() => useCustomCheckout(), {
+      wrapper,
+    });
+
+    expect(result.current).toBe(null);
+
+    await waitForNextUpdate();
+
+    await waitFor(() => expect(result.current).toEqual(mockCustomCheckout));
+  });
+
+  test('allows a transition from null to a valid Promise', async () => {
+    let stripeProp: any = null;
+    const wrapper = ({children}: any) => (
+      <CustomCheckoutProvider
+        stripe={stripeProp}
+        options={{clientSecret: 'cs_123'}}
+      >
+        {children}
+      </CustomCheckoutProvider>
+    );
+
+    const {result, rerender, waitForNextUpdate} = renderHook(
+      () => useCustomCheckout(),
+      {wrapper}
+    );
+    expect(result.current).toBe(null);
+
+    stripeProp = mockStripePromise;
+    act(() => rerender());
+
+    expect(result.current).toBe(null);
+
+    await waitForNextUpdate();
+
+    await waitFor(() => expect(result.current).toEqual(mockCustomCheckout));
+  });
+
+  test('does not set context if Promise resolves after Elements is unmounted', async () => {
+    // Silence console output so test output is less noisy
+    consoleError.mockImplementation(() => {});
+
+    let result: any;
+    act(() => {
+      result = render(
+        <CustomCheckoutProvider
+          stripe={mockStripePromise}
+          options={{clientSecret: 'cs_123'}}
+        >
+          {null}
+        </CustomCheckoutProvider>
+      );
+    });
+
+    result.unmount();
+    await act(() => mockStripePromise);
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('works with a Promise resolving to null for SSR safety', async () => {
+    const nullPromise = Promise.resolve(null);
+    const TestComponent = () => {
+      const customCheckout = useCustomCheckout();
+      return customCheckout ? <div>not empty</div> : null;
+    };
+
+    let result: any;
+    act(() => {
+      result = render(
+        <CustomCheckoutProvider
+          stripe={nullPromise}
+          options={{clientSecret: 'cs_123'}}
+        >
+          <TestComponent />
+        </CustomCheckoutProvider>
+      );
+    });
+
+    expect(result.container).toBeEmptyDOMElement();
+
+    await act(() => nullPromise.then(() => undefined));
+    expect(result.container).toBeEmptyDOMElement();
+  });
+
+  describe.each([
+    ['undefined', undefined],
+    ['false', false],
+    ['string', 'foo'],
+    ['random object', {foo: 'bar'}],
+  ])('invalid stripe prop', (name, stripeProp) => {
+    test(`errors when props.stripe is ${name}`, () => {
+      // Silence console output so test output is less noisy
+      consoleError.mockImplementation(() => {});
+
+      expect(() =>
+        render(
+          <CustomCheckoutProvider
+            stripe={stripeProp as any}
+            options={{clientSecret: 'cs_123'}}
+          >
+            <div />
+          </CustomCheckoutProvider>
+        )
+      ).toThrow('Invalid prop `stripe` supplied to `CustomCheckoutProvider`.');
+    });
+  });
+
+  test('does not allow changes to an already set Stripe object', async () => {
+    // Silence console output so test output is less noisy
+    consoleWarn.mockImplementation(() => {});
+    let result: any;
+    act(() => {
+      result = render(
+        <CustomCheckoutProvider
+          stripe={mockStripe}
+          options={{clientSecret: 'cs_123'}}
+        />
+      );
+    });
+
+    const mockStripe2: any = mocks.mockStripe();
+    act(() => {
+      result.rerender(
+        <CustomCheckoutProvider
+          stripe={mockStripe2}
+          options={{clientSecret: 'cs_123'}}
+        />
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(1);
+      expect(mockStripe2.initCustomCheckout).toHaveBeenCalledTimes(0);
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'Unsupported prop change on CustomCheckoutProvider: You cannot change the `stripe` prop after setting it.'
+      );
+    });
+  });
+
+  test('initCustomCheckout only called once and allows changes to elementsOptions appearance after setting the Stripe object', async () => {
+    let result: any;
+    act(() => {
+      result = render(
+        <CustomCheckoutProvider
+          stripe={mockStripe}
+          options={{
+            clientSecret: 'cs_123',
+            elementsOptions: {
+              appearance: {theme: 'stripe'},
+            },
+          }}
+        />
+      );
+    });
+
+    await waitFor(() =>
+      expect(mockStripe.initCustomCheckout).toHaveBeenCalledWith({
+        clientSecret: 'cs_123',
+        elementsOptions: {
+          appearance: {theme: 'stripe'},
+        },
+      })
+    );
+
+    act(() => {
+      result.rerender(
+        <CustomCheckoutProvider
+          stripe={mockStripe}
+          options={{
+            clientSecret: 'cs_123',
+            elementsOptions: {appearance: {theme: 'night'}},
+          }}
+        />
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(1);
+      expect(mockCustomCheckoutSdk.changeAppearance).toHaveBeenCalledTimes(1);
+      expect(mockCustomCheckoutSdk.changeAppearance).toHaveBeenCalledWith({
+        theme: 'night',
+      });
+    });
+  });
+
+  test('allows options changes before setting the Stripe object', async () => {
+    let result: any;
+    act(() => {
+      result = render(
+        <CustomCheckoutProvider
+          stripe={null}
+          options={{
+            clientSecret: 'cs_123',
+            elementsOptions: {
+              appearance: {theme: 'stripe'},
+            },
+          }}
+        />
+      );
+    });
+
+    await waitFor(() =>
+      expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(0)
+    );
+
+    act(() => {
+      result.rerender(
+        <CustomCheckoutProvider
+          stripe={mockStripe}
+          options={{
+            clientSecret: 'cs_123',
+            elementsOptions: {appearance: {theme: 'stripe'}},
+          }}
+        />
+      );
+    });
+
+    await waitFor(() => {
+      expect(console.warn).not.toHaveBeenCalled();
+      expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(1);
+      expect(mockStripe.initCustomCheckout).toHaveBeenCalledWith({
+        clientSecret: 'cs_123',
+        elementsOptions: {
+          appearance: {theme: 'stripe'},
+        },
+      });
+    });
+  });
+
+  test('throws when trying to call useCustomCheckout outside of CustomCheckoutProvider context', () => {
+    const {result} = renderHook(() => useCustomCheckout());
+
+    expect(result.error && result.error.message).toBe(
+      'Could not find CustomCheckoutProvider context; You need to wrap the part of your app that calls useCustomCheckout() in an <CustomCheckoutProvider> provider.'
+    );
+  });
+
+  test('throws when trying to call useStripe outside of CustomCheckoutProvider context', () => {
+    const {result} = renderHook(() => useStripe());
+
+    expect(result.error && result.error.message).toBe(
+      'Cannot find either Elements or CustomCheckout context; You need to wrap the part of your app that calls useStripe() in either <Elements> or <CustomCheckoutProvider> provider.'
+    );
+  });
+
+  describe('React.StrictMode', () => {
+    test('initCustomCheckout twice in StrictMode', async () => {
+      const TestComponent = () => {
+        const _ = useCustomCheckout();
+        return <div />;
+      };
+
+      act(() => {
+        render(
+          <StrictMode>
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <TestComponent />
+            </CustomCheckoutProvider>
+          </StrictMode>
+        );
+      });
+
+      await waitFor(() =>
+        expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(2)
+      );
+    });
+
+    test('initCustomCheckout once with stripePromise in StrictMode', async () => {
+      const TestComponent = () => {
+        const _ = useCustomCheckout();
+        return <div />;
+      };
+
+      act(() => {
+        render(
+          <StrictMode>
+            <CustomCheckoutProvider
+              stripe={mockStripePromise}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <TestComponent />
+            </CustomCheckoutProvider>
+          </StrictMode>
+        );
+      });
+
+      await waitFor(() =>
+        expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(1)
+      );
+    });
+
+    test('allows changes to options via elements.update after setting the Stripe object in StrictMode', async () => {
+      let result: any;
+      act(() => {
+        result = render(
+          <StrictMode>
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{
+                clientSecret: 'cs_123',
+                elementsOptions: {
+                  appearance: {theme: 'stripe'},
+                },
+              }}
+            />
+          </StrictMode>
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockStripe.initCustomCheckout).toHaveBeenCalledTimes(2);
+        expect(mockStripe.initCustomCheckout).toHaveBeenCalledWith({
+          clientSecret: 'cs_123',
+          elementsOptions: {
+            appearance: {theme: 'stripe'},
+          },
+        });
+      });
+
+      act(() => {
+        result.rerender(
+          <StrictMode>
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{
+                clientSecret: 'cs_123',
+                elementsOptions: {appearance: {theme: 'night'}},
+              }}
+            />
+          </StrictMode>
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockCustomCheckoutSdk.changeAppearance).toHaveBeenCalledTimes(1);
+        expect(mockCustomCheckoutSdk.changeAppearance).toHaveBeenCalledWith({
+          theme: 'night',
+        });
+      });
+    });
+  });
+});

--- a/src/components/CustomCheckout.test.tsx
+++ b/src/components/CustomCheckout.test.tsx
@@ -3,7 +3,7 @@ import {render, act, waitFor} from '@testing-library/react';
 import {renderHook} from '@testing-library/react-hooks';
 
 import {CustomCheckoutProvider, useCustomCheckout} from './CustomCheckout';
-import {useStripe} from './Elements';
+import {Elements, useStripe} from './Elements';
 import * as mocks from '../../test/mocks';
 
 describe('CustomCheckoutProvider', () => {
@@ -351,6 +351,50 @@ describe('CustomCheckoutProvider', () => {
 
     expect(result.error && result.error.message).toBe(
       'Could not find Elements context; You need to wrap the part of your app that calls useStripe() in an <Elements> provider.'
+    );
+  });
+
+  test('throws when trying to call useStripe in Elements -> CustomCheckoutProvider nested context', async () => {
+    const wrapper = ({children}: any) => (
+      <Elements stripe={mockStripe}>
+        <CustomCheckoutProvider
+          stripe={mockStripe}
+          options={{clientSecret: 'cs_123'}}
+        >
+          {children}
+        </CustomCheckoutProvider>
+      </Elements>
+    );
+
+    const {result, waitForNextUpdate} = renderHook(() => useStripe(), {
+      wrapper,
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.error && result.error.message).toBe(
+      'You cannot wrap the part of your app that calls useStripe() in both <CustomCheckoutProvider> and <Elements> providers.'
+    );
+  });
+
+  test('throws when trying to call useStripe in CustomCheckoutProvider -> Elements nested context', async () => {
+    const wrapper = ({children}: any) => (
+      <CustomCheckoutProvider
+        stripe={mockStripe}
+        options={{clientSecret: 'cs_123'}}
+      >
+        <Elements stripe={mockStripe}>{children}</Elements>
+      </CustomCheckoutProvider>
+    );
+
+    const {result, waitForNextUpdate} = renderHook(() => useStripe(), {
+      wrapper,
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.error && result.error.message).toBe(
+      'You cannot wrap the part of your app that calls useStripe() in both <CustomCheckoutProvider> and <Elements> providers.'
     );
   });
 

--- a/src/components/CustomCheckout.test.tsx
+++ b/src/components/CustomCheckout.test.tsx
@@ -3,7 +3,7 @@ import {render, act, waitFor} from '@testing-library/react';
 import {renderHook} from '@testing-library/react-hooks';
 
 import {CustomCheckoutProvider, useCustomCheckout} from './CustomCheckout';
-import {useStripe} from './CustomCheckout';
+import {useStripe} from './Elements';
 import * as mocks from '../../test/mocks';
 
 describe('CustomCheckoutProvider', () => {
@@ -350,7 +350,7 @@ describe('CustomCheckoutProvider', () => {
     const {result} = renderHook(() => useStripe());
 
     expect(result.error && result.error.message).toBe(
-      'Cannot find either Elements or CustomCheckout context; You need to wrap the part of your app that calls useStripe() in either <Elements> or <CustomCheckoutProvider> provider.'
+      'Could not find Elements context; You need to wrap the part of your app that calls useStripe() in an <Elements> provider.'
     );
   });
 

--- a/src/components/CustomCheckout.test.tsx
+++ b/src/components/CustomCheckout.test.tsx
@@ -91,7 +91,7 @@ describe('CustomCheckoutProvider', () => {
     );
 
     const {result, rerender} = renderHook(() => useCustomCheckout(), {wrapper});
-    expect(result.current).toBe(null);
+    expect(result.current).toBe(undefined);
 
     stripeProp = mockStripe;
     act(() => rerender());
@@ -112,7 +112,7 @@ describe('CustomCheckoutProvider', () => {
       wrapper,
     });
 
-    expect(result.current).toBe(null);
+    expect(result.current).toBe(undefined);
 
     await waitForNextUpdate();
 
@@ -134,12 +134,12 @@ describe('CustomCheckoutProvider', () => {
       () => useCustomCheckout(),
       {wrapper}
     );
-    expect(result.current).toBe(null);
+    expect(result.current).toBe(undefined);
 
     stripeProp = mockStripePromise;
     act(() => rerender());
 
-    expect(result.current).toBe(null);
+    expect(result.current).toBe(undefined);
 
     await waitForNextUpdate();
 

--- a/src/components/CustomCheckout.tsx
+++ b/src/components/CustomCheckout.tsx
@@ -240,7 +240,7 @@ export const useElementsOrCustomCheckoutSdkContextWithUseCase = (
 
   if (customCheckoutSdkContext && elementsContext) {
     throw new Error(
-      `You cannot wrap your app in both <CustomCheckoutProvider> and <Elements> providers.`
+      `You cannot wrap the part of your app that ${useCaseString} in both <CustomCheckoutProvider> and <Elements> providers.`
     );
   }
 
@@ -251,22 +251,7 @@ export const useElementsOrCustomCheckoutSdkContextWithUseCase = (
     );
   }
 
-  if (elementsContext) {
-    return parseElementsContext(elementsContext, useCaseString);
-  }
-
-  throw new Error(
-    `Cannot find either Elements or CustomCheckout context; You need to wrap the part of your app that ${useCaseString} in either <Elements> or <CustomCheckoutProvider> provider.`
-  );
-};
-/**
- * @docs https://stripe.com/docs/stripe-js/react#usestripe-hook
- */
-export const useStripe = (): stripeJs.Stripe | null => {
-  const {stripe} = useElementsOrCustomCheckoutSdkContextWithUseCase(
-    'calls useStripe()'
-  );
-  return stripe;
+  return parseElementsContext(elementsContext, useCaseString);
 };
 
 export const useCustomCheckout = (): CustomCheckoutContextValue | null => {

--- a/src/components/CustomCheckout.tsx
+++ b/src/components/CustomCheckout.tsx
@@ -47,12 +47,8 @@ const CustomCheckoutContext = React.createContext<CustomCheckoutContextValue | n
 CustomCheckoutContext.displayName = 'CustomCheckoutContext';
 
 export const extractCustomCheckoutContextValue = (
-  customCheckoutSdk: stripeJs.StripeCustomCheckout | null
-): CustomCheckoutContextValue | null => {
-  if (!customCheckoutSdk) {
-    return null;
-  }
-
+  customCheckoutSdk: stripeJs.StripeCustomCheckout
+): CustomCheckoutContextValue => {
   const {on: _on, session: _session, ...actions} = customCheckoutSdk;
   return {...actions, ...customCheckoutSdk.session()};
 };
@@ -204,9 +200,14 @@ export const CustomCheckoutProvider: FunctionComponent<PropsWithChildren<
     registerWithStripeJs(ctx.stripe);
   }, [ctx.stripe]);
 
+  if (!ctx.customCheckoutSdk) {
+    return null;
+  }
+
   const customCheckoutContextValue = extractCustomCheckoutContextValue(
     ctx.customCheckoutSdk
   );
+
   return (
     <CustomCheckoutSdkContext.Provider value={ctx}>
       <CustomCheckoutContext.Provider value={customCheckoutContextValue}>

--- a/src/components/CustomCheckout.tsx
+++ b/src/components/CustomCheckout.tsx
@@ -1,0 +1,275 @@
+import {FunctionComponent, PropsWithChildren, ReactNode} from 'react';
+import * as stripeJs from '@stripe/stripe-js';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {parseStripeProp} from '../utils/parseStripeProp';
+import {usePrevious} from '../utils/usePrevious';
+import {isUnknownObject} from '../utils/guards';
+import {isEqual} from '../utils/isEqual';
+import {
+  ElementsContext,
+  ElementsContextValue,
+  parseElementsContext,
+} from './Elements';
+import {registerWithStripeJs} from '../utils/registerWithStripeJs';
+
+interface CustomCheckoutSdkContextValue {
+  customCheckoutSdk: stripeJs.StripeCustomCheckout | null;
+  stripe: stripeJs.Stripe | null;
+}
+
+const CustomCheckoutSdkContext = React.createContext<CustomCheckoutSdkContextValue | null>(
+  null
+);
+CustomCheckoutSdkContext.displayName = 'CustomCheckoutSdkContext';
+
+export const parseCustomCheckoutSdkContext = (
+  ctx: CustomCheckoutSdkContextValue | null,
+  useCase: string
+): CustomCheckoutSdkContextValue => {
+  if (!ctx) {
+    throw new Error(
+      `Could not find CustomCheckoutProvider context; You need to wrap the part of your app that ${useCase} in an <CustomCheckoutProvider> provider.`
+    );
+  }
+
+  return ctx;
+};
+
+interface CustomCheckoutContextValue
+  extends stripeJs.StripeCustomCheckoutActions,
+    stripeJs.StripeCustomCheckoutSession {}
+const CustomCheckoutContext = React.createContext<CustomCheckoutContextValue | null>(
+  null
+);
+CustomCheckoutContext.displayName = 'CustomCheckoutContext';
+
+export const extractCustomCheckoutContextValue = (
+  customCheckoutSdk: stripeJs.StripeCustomCheckout | null
+): CustomCheckoutContextValue | null => {
+  if (!customCheckoutSdk) {
+    return null;
+  }
+
+  const {on: _on, session: _session, ...actions} = customCheckoutSdk;
+  return {...actions, ...customCheckoutSdk.session()};
+};
+
+interface CustomCheckoutProviderProps {
+  /**
+   * A [Stripe object](https://stripe.com/docs/js/initializing) or a `Promise` resolving to a `Stripe` object.
+   * The easiest way to initialize a `Stripe` object is with the the [Stripe.js wrapper module](https://github.com/stripe/stripe-js/blob/master/README.md#readme).
+   * Once this prop has been set, it can not be changed.
+   *
+   * You can also pass in `null` or a `Promise` resolving to `null` if you are performing an initial server-side render or when generating a static site.
+   */
+  stripe: PromiseLike<stripeJs.Stripe | null> | stripeJs.Stripe | null;
+  options: stripeJs.StripeCustomCheckoutOptions;
+}
+
+interface PrivateCustomCheckoutProviderProps {
+  stripe: unknown;
+  options: stripeJs.StripeCustomCheckoutOptions;
+  children?: ReactNode;
+}
+const INVALID_STRIPE_ERROR =
+  'Invalid prop `stripe` supplied to `CustomCheckoutProvider`. We recommend using the `loadStripe` utility from `@stripe/stripe-js`. See https://stripe.com/docs/stripe-js/react#elements-props-stripe for details.';
+
+export const CustomCheckoutProvider: FunctionComponent<PropsWithChildren<
+  CustomCheckoutProviderProps
+>> = (({
+  stripe: rawStripeProp,
+  options,
+  children,
+}: PrivateCustomCheckoutProviderProps) => {
+  const parsed = React.useMemo(
+    () => parseStripeProp(rawStripeProp, INVALID_STRIPE_ERROR),
+    [rawStripeProp]
+  );
+
+  // State used to trigger a re-render when sdk.session is updated
+  const [
+    _,
+    setSession,
+  ] = React.useState<stripeJs.StripeCustomCheckoutSession | null>(null);
+
+  // State used to avoid calling initCustomCheckout multiple times when options changes
+  const [
+    initCustomCheckoutCalled,
+    setInitCustomCheckoutCalled,
+  ] = React.useState<boolean>(false);
+
+  const [ctx, setContext] = React.useState<CustomCheckoutSdkContextValue>(
+    () => ({
+      stripe: parsed.tag === 'sync' ? parsed.stripe : null,
+      customCheckoutSdk: null,
+    })
+  );
+
+  const safeSetContext = (
+    stripe: stripeJs.Stripe,
+    customCheckoutSdk: stripeJs.StripeCustomCheckout
+  ) => {
+    setContext((ctx) => {
+      if (ctx.stripe && ctx.customCheckoutSdk) {
+        return ctx;
+      }
+
+      return {stripe, customCheckoutSdk};
+    });
+  };
+
+  React.useEffect(() => {
+    let isMounted = true;
+
+    if (parsed.tag === 'async' && !ctx.stripe) {
+      parsed.stripePromise.then((stripe) => {
+        if (stripe && isMounted && !initCustomCheckoutCalled) {
+          // Only update context if the component is still mounted
+          // and stripe is not null. We allow stripe to be null to make
+          // handling SSR easier.
+          setInitCustomCheckoutCalled(true);
+          stripe.initCustomCheckout(options).then((customCheckoutSdk) => {
+            if (customCheckoutSdk) {
+              safeSetContext(stripe, customCheckoutSdk);
+              customCheckoutSdk.on('change', setSession);
+            }
+          });
+        }
+      });
+    } else if (
+      parsed.tag === 'sync' &&
+      parsed.stripe &&
+      !initCustomCheckoutCalled
+    ) {
+      setInitCustomCheckoutCalled(true);
+      parsed.stripe.initCustomCheckout(options).then((customCheckoutSdk) => {
+        if (customCheckoutSdk) {
+          safeSetContext(parsed.stripe, customCheckoutSdk);
+          customCheckoutSdk.on('change', setSession);
+        }
+      });
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [
+    parsed,
+    ctx,
+    options,
+    initCustomCheckoutCalled,
+    setInitCustomCheckoutCalled,
+    setSession,
+  ]);
+
+  // Warn on changes to stripe prop
+  const prevStripe = usePrevious(rawStripeProp);
+  React.useEffect(() => {
+    if (prevStripe !== null && prevStripe !== rawStripeProp) {
+      console.warn(
+        'Unsupported prop change on CustomCheckoutProvider: You cannot change the `stripe` prop after setting it.'
+      );
+    }
+  }, [prevStripe, rawStripeProp]);
+
+  // Apply updates to elements when options prop has relevant changes
+  const prevOptions = usePrevious(options);
+  React.useEffect(() => {
+    if (!ctx.customCheckoutSdk) {
+      return;
+    }
+
+    if (
+      options.clientSecret &&
+      !isUnknownObject(prevOptions) &&
+      !isEqual(options.clientSecret, prevOptions.clientSecret)
+    ) {
+      console.warn(
+        'Unsupported prop change: options.client_secret is not a mutable property.'
+      );
+    }
+
+    const previousAppearance = prevOptions?.elementsOptions?.appearance;
+    const currentAppearance = options?.elementsOptions?.appearance;
+    if (currentAppearance && !isEqual(currentAppearance, previousAppearance)) {
+      ctx.customCheckoutSdk.changeAppearance(currentAppearance);
+    }
+  }, [options, prevOptions, ctx.customCheckoutSdk]);
+
+  // Attach react-stripe-js version to stripe.js instance
+  React.useEffect(() => {
+    registerWithStripeJs(ctx.stripe);
+  }, [ctx.stripe]);
+
+  const customCheckoutContextValue = extractCustomCheckoutContextValue(
+    ctx.customCheckoutSdk
+  );
+  return (
+    <CustomCheckoutSdkContext.Provider value={ctx}>
+      <CustomCheckoutContext.Provider value={customCheckoutContextValue}>
+        {children}
+      </CustomCheckoutContext.Provider>
+    </CustomCheckoutSdkContext.Provider>
+  );
+}) as FunctionComponent<PropsWithChildren<CustomCheckoutProviderProps>>;
+
+CustomCheckoutProvider.propTypes = {
+  stripe: PropTypes.any,
+  options: PropTypes.shape({
+    clientSecret: PropTypes.string.isRequired,
+    elementsOptions: PropTypes.object as any,
+  }).isRequired,
+};
+
+export const useCustomCheckoutSdkContextWithUseCase = (
+  useCaseString: string
+): CustomCheckoutSdkContextValue => {
+  const ctx = React.useContext(CustomCheckoutSdkContext);
+  return parseCustomCheckoutSdkContext(ctx, useCaseString);
+};
+
+export const useElementsOrCustomCheckoutSdkContextWithUseCase = (
+  useCaseString: string
+): CustomCheckoutSdkContextValue | ElementsContextValue => {
+  const customCheckoutSdkContext = React.useContext(CustomCheckoutSdkContext);
+  const elementsContext = React.useContext(ElementsContext);
+
+  if (customCheckoutSdkContext && elementsContext) {
+    throw new Error(
+      `You cannot wrap your app in both <CustomCheckoutProvider> and <Elements> providers.`
+    );
+  }
+
+  if (customCheckoutSdkContext) {
+    return parseCustomCheckoutSdkContext(
+      customCheckoutSdkContext,
+      useCaseString
+    );
+  }
+
+  if (elementsContext) {
+    return parseElementsContext(elementsContext, useCaseString);
+  }
+
+  throw new Error(
+    `Cannot find either Elements or CustomCheckout context; You need to wrap the part of your app that ${useCaseString} in either <Elements> or <CustomCheckoutProvider> provider.`
+  );
+};
+/**
+ * @docs https://stripe.com/docs/stripe-js/react#usestripe-hook
+ */
+export const useStripe = (): stripeJs.Stripe | null => {
+  const {stripe} = useElementsOrCustomCheckoutSdkContextWithUseCase(
+    'calls useStripe()'
+  );
+  return stripe;
+};
+
+export const useCustomCheckout = (): CustomCheckoutContextValue | null => {
+  // ensure it's in CustomCheckoutProvider
+  useCustomCheckoutSdkContextWithUseCase('calls useCustomCheckout()');
+  return React.useContext(CustomCheckoutContext);
+};

--- a/src/components/Elements.test.tsx
+++ b/src/components/Elements.test.tsx
@@ -5,11 +5,11 @@ import {renderHook} from '@testing-library/react-hooks';
 import {
   Elements,
   useElements,
-  useStripe,
   ElementsConsumer,
   useCartElement,
   useCartElementState,
 } from './Elements';
+import {useStripe} from './CustomCheckout';
 import * as mocks from '../../test/mocks';
 
 describe('Elements', () => {
@@ -283,7 +283,7 @@ describe('Elements', () => {
     const {result} = renderHook(() => useStripe());
 
     expect(result.error && result.error.message).toBe(
-      'Could not find Elements context; You need to wrap the part of your app that calls useStripe() in an <Elements> provider.'
+      'Cannot find either Elements or CustomCheckout context; You need to wrap the part of your app that calls useStripe() in either <Elements> or <CustomCheckoutProvider> provider.'
     );
   });
 

--- a/src/components/Elements.test.tsx
+++ b/src/components/Elements.test.tsx
@@ -8,8 +8,8 @@ import {
   ElementsConsumer,
   useCartElement,
   useCartElementState,
+  useStripe,
 } from './Elements';
-import {useStripe} from './CustomCheckout';
 import * as mocks from '../../test/mocks';
 
 describe('Elements', () => {
@@ -283,7 +283,7 @@ describe('Elements', () => {
     const {result} = renderHook(() => useStripe());
 
     expect(result.error && result.error.message).toBe(
-      'Cannot find either Elements or CustomCheckout context; You need to wrap the part of your app that calls useStripe() in either <Elements> or <CustomCheckoutProvider> provider.'
+      'Could not find Elements context; You need to wrap the part of your app that calls useStripe() in an <Elements> provider.'
     );
   });
 

--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -17,6 +17,7 @@ import {
 } from '../utils/extractAllowedOptionsUpdates';
 import {parseStripeProp} from '../utils/parseStripeProp';
 import {registerWithStripeJs} from '../utils/registerWithStripeJs';
+import {useElementsOrCustomCheckoutSdkContextWithUseCase} from './CustomCheckout';
 
 export interface ElementsContextValue {
   elements: stripeJs.StripeElements | null;
@@ -237,6 +238,16 @@ export const useCartElementContextWithUseCase = (
 export const useElements = (): stripeJs.StripeElements | null => {
   const {elements} = useElementsContextWithUseCase('calls useElements()');
   return elements;
+};
+
+/**
+ * @docs https://stripe.com/docs/stripe-js/react#usestripe-hook
+ */
+export const useStripe = (): stripeJs.Stripe | null => {
+  const {stripe} = useElementsOrCustomCheckoutSdkContextWithUseCase(
+    'calls useStripe()'
+  );
+  return stripe;
 };
 
 /**

--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -18,12 +18,14 @@ import {
 import {parseStripeProp} from '../utils/parseStripeProp';
 import {registerWithStripeJs} from '../utils/registerWithStripeJs';
 
-interface ElementsContextValue {
+export interface ElementsContextValue {
   elements: stripeJs.StripeElements | null;
   stripe: stripeJs.Stripe | null;
 }
 
-const ElementsContext = React.createContext<ElementsContextValue | null>(null);
+export const ElementsContext = React.createContext<ElementsContextValue | null>(
+  null
+);
 ElementsContext.displayName = 'ElementsContext';
 
 export const parseElementsContext = (
@@ -211,10 +213,21 @@ export const useElementsContextWithUseCase = (
   return parseElementsContext(ctx, useCaseMessage);
 };
 
+const DUMMY_CART_ELEMENT_CONTEXT: CartElementContextValue = {
+  cart: null,
+  cartState: null,
+  setCart: () => {},
+  setCartState: () => {},
+};
+
 export const useCartElementContextWithUseCase = (
-  useCaseMessage: string
+  useCaseMessage: string,
+  isInCustomCheckout = false
 ): CartElementContextValue => {
   const ctx = React.useContext(CartElementContext);
+  if (isInCustomCheckout) {
+    return DUMMY_CART_ELEMENT_CONTEXT;
+  }
   return parseCartElementContext(ctx, useCaseMessage);
 };
 
@@ -224,14 +237,6 @@ export const useCartElementContextWithUseCase = (
 export const useElements = (): stripeJs.StripeElements | null => {
   const {elements} = useElementsContextWithUseCase('calls useElements()');
   return elements;
-};
-
-/**
- * @docs https://stripe.com/docs/stripe-js/react#usestripe-hook
- */
-export const useStripe = (): stripeJs.Stripe | null => {
-  const {stripe} = useElementsContextWithUseCase('calls useStripe()');
-  return stripe;
 };
 
 /**

--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -132,7 +132,7 @@ describe('createElementComponent', () => {
         (console.error as any).mockImplementation(() => {});
 
         expect(() => render(<CardElement />)).toThrow(
-          'Cannot find either Elements or CustomCheckout context; You need to wrap the part of your app that mounts <CardElement> in either <Elements> or <CustomCheckoutProvider> provider.'
+          'Could not find Elements context; You need to wrap the part of your app that mounts <CardElement> in an <Elements> provider.'
         );
       });
 
@@ -310,7 +310,7 @@ describe('createElementComponent', () => {
       (console.error as any).mockImplementation(() => {});
 
       expect(() => render(<CardElement />)).toThrow(
-        'Cannot find either Elements or CustomCheckout context; You need to wrap the part of your app that mounts <CardElement> in either <Elements> or <CustomCheckoutProvider> provider.'
+        'Could not find Elements context; You need to wrap the part of your app that mounts <CardElement> in an <Elements> provider.'
       );
     });
 

--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -1,7 +1,8 @@
 import React, {StrictMode} from 'react';
-import {render, act} from '@testing-library/react';
+import {render, act, waitFor} from '@testing-library/react';
 
 import * as ElementsModule from './Elements';
+import * as CustomCheckoutModule from './CustomCheckout';
 import createElementComponent from './createElementComponent';
 import * as mocks from '../../test/mocks';
 import {
@@ -13,12 +14,14 @@ import {
 } from '../types';
 
 const {Elements} = ElementsModule;
+const {CustomCheckoutProvider} = CustomCheckoutModule;
 
 describe('createElementComponent', () => {
   let mockStripe: any;
   let mockElements: any;
   let mockElement: any;
   let mockCartElementContext: any;
+  let mockCustomCheckoutSdk: any;
 
   let simulateElementsEvents: Record<string, any[]>;
   let simulateOn: any;
@@ -30,9 +33,12 @@ describe('createElementComponent', () => {
   beforeEach(() => {
     mockStripe = mocks.mockStripe();
     mockElements = mocks.mockElements();
+    mockCustomCheckoutSdk = mocks.mockCustomCheckoutSdk();
     mockElement = mocks.mockElement();
     mockStripe.elements.mockReturnValue(mockElements);
     mockElements.create.mockReturnValue(mockElement);
+    mockStripe.initCustomCheckout.mockResolvedValue(mockCustomCheckoutSdk);
+    mockCustomCheckoutSdk.createElement.mockReturnValue(mockElement);
     jest.spyOn(React, 'useLayoutEffect');
 
     simulateElementsEvents = {};
@@ -61,59 +67,69 @@ describe('createElementComponent', () => {
     jest.restoreAllMocks();
   });
 
-  describe('on the server', () => {
-    const CardElement = createElementComponent('card', true);
+  describe.each([
+    ['Elements', Elements, {clientSecret: 'pi_123'}],
+    [
+      'CustomCheckoutProvider',
+      CustomCheckoutProvider,
+      {clientSecret: 'cs_123'},
+    ],
+  ])(
+    'on the server with Provider - %s',
+    (_providerName, Provider, providerOptions) => {
+      const CardElement = createElementComponent('card', true);
 
-    it('gives the element component a proper displayName', () => {
-      expect(CardElement.displayName).toBe('CardElement');
-    });
+      it('gives the element component a proper displayName', () => {
+        expect(CardElement.displayName).toBe('CardElement');
+      });
 
-    it('stores the element component`s type as a static property', () => {
-      expect((CardElement as any).__elementType).toBe('card');
-    });
+      it('stores the element component`s type as a static property', () => {
+        expect((CardElement as any).__elementType).toBe('card');
+      });
 
-    it('passes id to the wrapping DOM element', () => {
-      const {container} = render(
-        <Elements stripe={null}>
-          <CardElement id="foo" />
-        </Elements>
-      );
+      it('passes id to the wrapping DOM element', () => {
+        const {container} = render(
+          <Provider stripe={null} options={providerOptions}>
+            <CardElement id="foo" />
+          </Provider>
+        );
 
-      const elementContainer = container.firstChild as Element;
+        const elementContainer = container.firstChild as Element;
 
-      expect(elementContainer.id).toBe('foo');
-    });
+        expect(elementContainer.id).toBe('foo');
+      });
 
-    it('passes className to the wrapping DOM element', () => {
-      const {container} = render(
-        <Elements stripe={null}>
-          <CardElement className="bar" />
-        </Elements>
-      );
-      const elementContainer = container.firstChild as Element;
-      expect(elementContainer).toHaveClass('bar');
-    });
+      it('passes className to the wrapping DOM element', () => {
+        const {container} = render(
+          <Provider stripe={null} options={providerOptions}>
+            <CardElement className="bar" />
+          </Provider>
+        );
+        const elementContainer = container.firstChild as Element;
+        expect(elementContainer).toHaveClass('bar');
+      });
 
-    it('throws when the Element is mounted outside of Elements context', () => {
-      // Prevent the console.errors to keep the test output clean
-      jest.spyOn(console, 'error');
-      (console.error as any).mockImplementation(() => {});
+      it('throws when the Element is mounted outside of Elements context', () => {
+        // Prevent the console.errors to keep the test output clean
+        jest.spyOn(console, 'error');
+        (console.error as any).mockImplementation(() => {});
 
-      expect(() => render(<CardElement />)).toThrow(
-        'Could not find Elements context; You need to wrap the part of your app that mounts <CardElement> in an <Elements> provider.'
-      );
-    });
+        expect(() => render(<CardElement />)).toThrow(
+          'Cannot find either Elements or CustomCheckout context; You need to wrap the part of your app that mounts <CardElement> in either <Elements> or <CustomCheckoutProvider> provider.'
+        );
+      });
 
-    it('does not call useLayoutEffect', () => {
-      render(
-        <Elements stripe={null}>
-          <CardElement />
-        </Elements>
-      );
+      it('does not call useLayoutEffect', () => {
+        render(
+          <Provider stripe={null} options={providerOptions}>
+            <CardElement />
+          </Provider>
+        );
 
-      expect(React.useLayoutEffect).not.toHaveBeenCalled();
-    });
-  });
+        expect(React.useLayoutEffect).not.toHaveBeenCalled();
+      });
+    }
+  );
 
   describe('on the client', () => {
     const CardElement: CardElementComponent = createElementComponent(
@@ -277,7 +293,7 @@ describe('createElementComponent', () => {
       (console.error as any).mockImplementation(() => {});
 
       expect(() => render(<CardElement />)).toThrow(
-        'Could not find Elements context; You need to wrap the part of your app that mounts <CardElement> in an <Elements> provider.'
+        'Cannot find either Elements or CustomCheckout context; You need to wrap the part of your app that mounts <CardElement> in either <Elements> or <CustomCheckoutProvider> provider.'
       );
     });
 
@@ -296,7 +312,10 @@ describe('createElementComponent', () => {
 
     it('attaches event listeners once the element is created', () => {
       jest
-        .spyOn(ElementsModule, 'useElementsContextWithUseCase')
+        .spyOn(
+          CustomCheckoutModule,
+          'useElementsOrCustomCheckoutSdkContextWithUseCase'
+        )
         .mockReturnValueOnce({elements: null, stripe: null})
         .mockReturnValue({elements: mockElements, stripe: mockStripe});
 
@@ -960,6 +979,775 @@ describe('createElementComponent', () => {
 
       expect(mockElement.update).toHaveBeenCalledWith({
         style: {base: {fontSize: '30px'}},
+      });
+    });
+
+    describe('Within a CustomCheckoutProvider', () => {
+      let peMounted = false;
+      let result: any;
+      beforeEach(() => {
+        peMounted = false;
+        result = null;
+
+        mockElement.mount.mockImplementation(() => {
+          if (peMounted) {
+            throw new Error('Card already mounted');
+          }
+          peMounted = true;
+        });
+        mockElement.destroy.mockImplementation(() => {
+          peMounted = false;
+        });
+      });
+      it('Can remove and add CardElement at the same time', async () => {
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement key={'100'} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        expect(mockElement.mount).toHaveBeenCalledTimes(1);
+
+        const rerender = result.rerender;
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement key={'200'} />
+            </CustomCheckoutProvider>
+          );
+        });
+
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        expect(mockElement.mount).toHaveBeenCalledTimes(2);
+      });
+
+      it('passes id to the wrapping DOM element', async () => {
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement id="foo" />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {container} = result;
+        const elementContainer = container.firstChild as Element;
+
+        expect(elementContainer.id).toBe('foo');
+      });
+
+      it('passes className to the wrapping DOM element', async () => {
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement className="bar" />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {container} = result;
+        const elementContainer = container.firstChild as Element;
+
+        expect(elementContainer).toHaveClass('bar');
+      });
+
+      it('creates the element with options', async () => {
+        const options: any = {foo: 'foo'};
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement options={options} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        expect(mockCustomCheckoutSdk.createElement).toHaveBeenCalledWith(
+          'payment',
+          options
+        );
+        expect(simulateOn).not.toBeCalled();
+        expect(simulateOff).not.toBeCalled();
+      });
+
+      it('creates, no destory in strict mode', async () => {
+        let elementCreated = false;
+
+        mockCustomCheckoutSdk.createElement.mockImplementation(() => {
+          expect(elementCreated).toBe(false);
+          elementCreated = true;
+
+          return mockElement;
+        });
+
+        mockElement.destroy.mockImplementation(() => {
+          elementCreated = false;
+        });
+
+        act(() => {
+          result = render(
+            <StrictMode>
+              <CustomCheckoutProvider
+                stripe={mockStripe}
+                options={{clientSecret: 'cs_123'}}
+              >
+                <PaymentElement />
+              </CustomCheckoutProvider>
+            </StrictMode>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        expect(mockCustomCheckoutSdk.createElement).toHaveBeenCalledTimes(1);
+        expect(mockElement.destroy).toHaveBeenCalledTimes(0);
+      });
+
+      it('mounts the element', async () => {
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        const {container} = result;
+
+        expect(mockElement.mount).toHaveBeenCalledWith(container.firstChild);
+        expect(React.useLayoutEffect).toHaveBeenCalled();
+
+        expect(simulateOn).not.toBeCalled();
+        expect(simulateOff).not.toBeCalled();
+      });
+
+      it('does not create and mount until CustomCheckoutSdk has been instantiated', async () => {
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={null}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement />
+            </CustomCheckoutProvider>
+          );
+        });
+
+        expect(mockElement.mount).not.toHaveBeenCalled();
+        expect(mockElements.create).not.toHaveBeenCalled();
+
+        const {rerender} = result;
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        expect(mockElement.mount).toHaveBeenCalled();
+        expect(mockCustomCheckoutSdk.createElement).toHaveBeenCalled();
+      });
+
+      it('adds an event handlers to an Element', async () => {
+        const mockHandler = jest.fn();
+
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onChange={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        const changeEventMock = Symbol('change');
+        simulateEvent('change', changeEventMock);
+        expect(mockHandler).toHaveBeenCalledWith(changeEventMock);
+      });
+
+      it('attaches event listeners once the element is created', async () => {
+        jest
+          .spyOn(
+            CustomCheckoutModule,
+            'useElementsOrCustomCheckoutSdkContextWithUseCase'
+          )
+          .mockReturnValueOnce({
+            customCheckoutSdk: null,
+            stripe: null,
+          })
+          .mockReturnValue({
+            customCheckoutSdk: mockCustomCheckoutSdk,
+            stripe: mockStripe,
+          });
+
+        const mockHandler = jest.fn();
+
+        // This won't create the element, since elements is undefined on this render
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onChange={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        expect(mockElements.create).not.toBeCalled();
+
+        expect(simulateOn).not.toBeCalled();
+
+        // This creates the element now that elements is defined
+        const {rerender} = result;
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onChange={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        expect(mockCustomCheckoutSdk.createElement).toBeCalled();
+
+        expect(simulateOn).toBeCalledWith('change', expect.any(Function));
+        expect(simulateOff).not.toBeCalled();
+
+        const changeEventMock = Symbol('change');
+        simulateEvent('change', changeEventMock);
+        expect(mockHandler).toHaveBeenCalledWith(changeEventMock);
+      });
+
+      it('adds event handler on re-render', async () => {
+        const mockHandler = jest.fn();
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onChange={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        expect(simulateOn).toBeCalledWith('change', expect.any(Function));
+        expect(simulateOff).not.toBeCalled();
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onChange={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        expect(simulateOn).toBeCalledWith('change', expect.any(Function));
+      });
+
+      it('removes event handler when removed on re-render', async () => {
+        const mockHandler = jest.fn();
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onChange={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        expect(simulateOn).toBeCalledWith('change', expect.any(Function));
+        expect(simulateOff).not.toBeCalled();
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        expect(simulateOff).toBeCalledWith('change', expect.any(Function));
+      });
+
+      it('does not call on/off when an event handler changes', async () => {
+        const mockHandler = jest.fn();
+        const mockHandler2 = jest.fn();
+
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onChange={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        expect(simulateOn).toBeCalledWith('change', expect.any(Function));
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onChange={mockHandler2} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        expect(simulateOn).toBeCalledTimes(1);
+        expect(simulateOff).not.toBeCalled();
+      });
+
+      it('propagates the Element`s ready event to the current onReady prop', async () => {
+        const mockHandler = jest.fn();
+        const mockHandler2 = jest.fn();
+
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onReady={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onReady={mockHandler2} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        const mockEvent = Symbol('ready');
+        simulateEvent('ready', mockEvent);
+        expect(mockHandler2).toHaveBeenCalledWith(mockElement);
+        expect(mockHandler).not.toHaveBeenCalled();
+      });
+
+      it('propagates the Element`s change event to the current onChange prop', async () => {
+        const mockHandler = jest.fn();
+        const mockHandler2 = jest.fn();
+
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onChange={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onChange={mockHandler2} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        const changeEventMock = Symbol('change');
+        simulateEvent('change', changeEventMock);
+        expect(mockHandler2).toHaveBeenCalledWith(changeEventMock);
+        expect(mockHandler).not.toHaveBeenCalled();
+      });
+
+      it('propagates the Element`s blur event to the current onBlur prop', async () => {
+        const mockHandler = jest.fn();
+        const mockHandler2 = jest.fn();
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onBlur={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onBlur={mockHandler2} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        simulateEvent('blur');
+        expect(mockHandler2).toHaveBeenCalledWith();
+        expect(mockHandler).not.toHaveBeenCalled();
+      });
+
+      it('propagates the Element`s focus event to the current onFocus prop', async () => {
+        const mockHandler = jest.fn();
+        const mockHandler2 = jest.fn();
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onFocus={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onFocus={mockHandler2} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        simulateEvent('focus');
+        expect(mockHandler2).toHaveBeenCalledWith();
+        expect(mockHandler).not.toHaveBeenCalled();
+      });
+
+      it('propagates the Element`s escape event to the current onEscape prop', async () => {
+        const mockHandler = jest.fn();
+        const mockHandler2 = jest.fn();
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onEscape={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onEscape={mockHandler2} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        simulateEvent('escape');
+        expect(mockHandler2).toHaveBeenCalledWith();
+        expect(mockHandler).not.toHaveBeenCalled();
+      });
+
+      it('propagates the Element`s loaderror event to the current onLoadError prop', async () => {
+        const mockHandler = jest.fn();
+        const mockHandler2 = jest.fn();
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onLoadError={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onLoadError={mockHandler2} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        simulateEvent('loaderror');
+        expect(mockHandler2).toHaveBeenCalledWith();
+        expect(mockHandler).not.toHaveBeenCalled();
+      });
+
+      it('propagates the Element`s loaderstart event to the current onLoaderStart prop', async () => {
+        const mockHandler = jest.fn();
+        const mockHandler2 = jest.fn();
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onLoaderStart={mockHandler} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement onLoaderStart={mockHandler2} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        simulateEvent('loaderstart');
+        expect(mockHandler2).toHaveBeenCalledWith();
+        expect(mockHandler).not.toHaveBeenCalled();
+      });
+
+      it('updates the Element when options change', async () => {
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement options={{layout: 'accordion'}} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement options={{layout: 'tabs'}} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        expect(mockElement.update).toHaveBeenCalledWith({
+          layout: 'tabs',
+        });
+      });
+
+      it('does not trigger unnecessary updates', async () => {
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement options={{layout: 'accordion'}} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement options={{layout: 'accordion'}} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        expect(mockElement.update).not.toHaveBeenCalled();
+      });
+
+      it('updates the Element when options change from null to non-null value', async () => {
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              {/* @ts-expect-error */}
+              <PaymentElement options={null} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {rerender} = result;
+
+        act(() => {
+          rerender(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement options={{layout: 'tabs'}} />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+
+        expect(mockElement.update).toHaveBeenCalledWith({
+          layout: 'tabs',
+        });
+      });
+
+      it('destroys an existing Element when the component unmounts', async () => {
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={null}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement />
+            </CustomCheckoutProvider>
+          );
+        });
+        const {unmount} = result;
+        unmount();
+
+        // not called when Element has not been mounted (because stripe is still loading)
+        expect(mockElement.destroy).not.toHaveBeenCalled();
+
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={mockStripe}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {unmount: unmount2} = result;
+        unmount2();
+
+        expect(mockElement.destroy).toHaveBeenCalled();
+      });
+
+      it('destroys an existing Element when the component unmounts with an async stripe prop', async () => {
+        const stripePromise = Promise.resolve(mockStripe);
+
+        act(() => {
+          result = render(
+            <CustomCheckoutProvider
+              stripe={stripePromise}
+              options={{clientSecret: 'cs_123'}}
+            >
+              <PaymentElement />
+            </CustomCheckoutProvider>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {unmount} = result;
+        unmount();
+
+        expect(mockElement.destroy).toHaveBeenCalled();
+      });
+
+      it('destroys an existing Element when the component unmounts with an async stripe prop in StrictMode', async () => {
+        const stripePromise = Promise.resolve(mockStripe);
+        act(() => {
+          result = render(
+            <StrictMode>
+              <CustomCheckoutProvider
+                stripe={stripePromise}
+                options={{clientSecret: 'cs_123'}}
+              >
+                <PaymentElement />
+              </CustomCheckoutProvider>
+            </StrictMode>
+          );
+        });
+        await waitFor(() => expect(peMounted).toBeTruthy());
+        const {unmount} = result;
+        unmount();
+
+        expect(mockElement.destroy).toHaveBeenCalled();
       });
     });
   });

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -212,11 +212,10 @@ const createElementComponent = (
     const ctx = useElementsOrCustomCheckoutSdkContextWithUseCase(
       `mounts <${displayName}>`
     );
-    const customCheckoutSdk =
-      'customCheckoutSdk' in ctx ? ctx.customCheckoutSdk : null;
+
     useCartElementContextWithUseCase(
       `mounts <${displayName}>`,
-      !!customCheckoutSdk
+      'customCheckoutSdk' in ctx
     );
     const {id, className} = props;
     return <div id={id} className={className} />;

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -6,10 +6,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
-import {
-  useElementsContextWithUseCase,
-  useCartElementContextWithUseCase,
-} from './Elements';
+import {useCartElementContextWithUseCase} from './Elements';
 import {useAttachEvent} from '../utils/useAttachEvent';
 import {ElementProps} from '../types';
 import {usePrevious} from '../utils/usePrevious';
@@ -17,6 +14,7 @@ import {
   extractAllowedOptionsUpdates,
   UnknownOptions,
 } from '../utils/extractAllowedOptionsUpdates';
+import {useElementsOrCustomCheckoutSdkContextWithUseCase} from './CustomCheckout';
 
 type UnknownCallback = (...args: unknown[]) => any;
 
@@ -69,7 +67,12 @@ const createElementComponent = (
     onShippingAddressChange,
     onShippingRateChange,
   }) => {
-    const {elements} = useElementsContextWithUseCase(`mounts <${displayName}>`);
+    const ctx = useElementsOrCustomCheckoutSdkContextWithUseCase(
+      `mounts <${displayName}>`
+    );
+    const elements = 'elements' in ctx ? ctx.elements : null;
+    const customCheckoutSdk =
+      'customCheckoutSdk' in ctx ? ctx.customCheckoutSdk : null;
     const [element, setElement] = React.useState<stripeJs.StripeElement | null>(
       null
     );
@@ -77,7 +80,8 @@ const createElementComponent = (
     const domNode = React.useRef<HTMLDivElement | null>(null);
 
     const {setCart, setCartState} = useCartElementContextWithUseCase(
-      `mounts <${displayName}>`
+      `mounts <${displayName}>`,
+      'customCheckoutSdk' in ctx
     );
 
     // For every event where the merchant provides a callback, call element.on
@@ -139,8 +143,18 @@ const createElementComponent = (
     useAttachEvent(element, 'checkout', checkoutCallback);
 
     React.useLayoutEffect(() => {
-      if (elementRef.current === null && elements && domNode.current !== null) {
-        const newElement = elements.create(type as any, options);
+      if (
+        elementRef.current === null &&
+        domNode.current !== null &&
+        (elements || customCheckoutSdk)
+      ) {
+        let newElement: stripeJs.StripeElement | null = null;
+        if (customCheckoutSdk) {
+          newElement = customCheckoutSdk.createElement(type as any, options);
+        } else if (elements) {
+          newElement = elements.create(type as any, options);
+        }
+
         if (type === 'cart' && setCart) {
           // we know that elements.create return value must be of type StripeCartElement if type is 'cart',
           // we need to cast because typescript is not able to infer which overloaded method is used based off param type
@@ -152,9 +166,11 @@ const createElementComponent = (
         // Store element in state to facilitate event listener attachment
         setElement(newElement);
 
-        newElement.mount(domNode.current);
+        if (newElement) {
+          newElement.mount(domNode.current);
+        }
       }
-    }, [elements, options, setCart]);
+    }, [elements, customCheckoutSdk, options, setCart]);
 
     const prevOptions = usePrevious(options);
     React.useEffect(() => {
@@ -193,8 +209,15 @@ const createElementComponent = (
   // Only render the Element wrapper in a server environment.
   const ServerElement: FunctionComponent<PrivateElementProps> = (props) => {
     // Validate that we are in the right context by calling useElementsContextWithUseCase.
-    useElementsContextWithUseCase(`mounts <${displayName}>`);
-    useCartElementContextWithUseCase(`mounts <${displayName}>`);
+    const ctx = useElementsOrCustomCheckoutSdkContextWithUseCase(
+      `mounts <${displayName}>`
+    );
+    const customCheckoutSdk =
+      'customCheckoutSdk' in ctx ? ctx.customCheckoutSdk : null;
+    useCartElementContextWithUseCase(
+      `mounts <${displayName}>`,
+      !!customCheckoutSdk
+    );
     const {id, className} = props;
     return <div id={id} className={className} />;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
 export * from './types';
 
 export {
+  useStripe,
   useElements,
   useCartElement,
   useCartElementState,
@@ -33,7 +34,6 @@ export {
 } from './components/Elements';
 
 export {
-  useStripe,
   useCustomCheckout,
   CustomCheckoutProvider,
 } from './components/CustomCheckout';

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,12 +26,17 @@ export * from './types';
 
 export {
   useElements,
-  useStripe,
   useCartElement,
   useCartElementState,
   Elements,
   ElementsConsumer,
 } from './components/Elements';
+
+export {
+  useStripe,
+  useCustomCheckout,
+  CustomCheckoutProvider,
+} from './components/CustomCheckout';
 
 const isServer = typeof window === 'undefined';
 

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -19,17 +19,65 @@ export const mockElements = () => {
   };
 };
 
-export const mockStripe = () => ({
-  elements: jest.fn(() => mockElements()),
-  createToken: jest.fn(),
-  createSource: jest.fn(),
-  createPaymentMethod: jest.fn(),
-  confirmCardPayment: jest.fn(),
-  confirmCardSetup: jest.fn(),
-  paymentRequest: jest.fn(),
-  registerAppInfo: jest.fn(),
-  _registerWrapper: jest.fn(),
-});
+export const mockCustomCheckoutSession = () => {
+  return {
+    lineItems: [],
+    currency: 'usd',
+    shippingOptions: [],
+    total: {
+      subtotal: 1099,
+      taxExclusive: 0,
+      taxInclusive: 0,
+      shippingRate: 0,
+      discount: 0,
+      total: 1099,
+    },
+    confirmationRequirements: [],
+    canConfirm: true,
+  };
+};
+
+export const mockCustomCheckoutSdk = () => {
+  const elements = {};
+
+  return {
+    changeAppearance: jest.fn(),
+    createElement: jest.fn((type) => {
+      elements[type] = mockElement();
+      return elements[type];
+    }),
+    getElement: jest.fn((type) => {
+      return elements[type] || null;
+    }),
+    session: jest.fn(() => mockCustomCheckoutSession()),
+    applyPromotionCode: jest.fn(),
+    removePromotionCode: jest.fn(),
+    updateShippingAddress: jest.fn(),
+    updateBillingAddress: jest.fn(),
+    updatePhoneNumber: jest.fn(),
+    updateEmail: jest.fn(),
+    updateLineItemQuantity: jest.fn(),
+    updateShippingOption: jest.fn(),
+    confirm: jest.fn(),
+    on: jest.fn(),
+  };
+};
+
+export const mockStripe = () => {
+  const customCheckoutSdk = mockCustomCheckoutSdk();
+  return {
+    elements: jest.fn(() => mockElements()),
+    createToken: jest.fn(),
+    createSource: jest.fn(),
+    createPaymentMethod: jest.fn(),
+    confirmCardPayment: jest.fn(),
+    confirmCardSetup: jest.fn(),
+    paymentRequest: jest.fn(),
+    registerAppInfo: jest.fn(),
+    _registerWrapper: jest.fn(),
+    initCustomCheckout: jest.fn().mockResolvedValue(customCheckoutSdk),
+  };
+};
 
 export const mockCartElementContext = () => {
   const cartElementContext = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,10 +2130,10 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
-"@stripe/stripe-js@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-2.0.0.tgz#74377dbdfcfee13043ed7d130a69ba15eb18b9ce"
-  integrity sha512-SxZnf192En0uAfgbigUIj7oJYaXgGc5AI1aos59YXvO8DPeLI0AtT4oMg/Wuk17wbpquEv73+akyCe7xdEjGlA==
+"@stripe/stripe-js@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-2.1.1.tgz#dd540bb9e764ef9e6fe54bbff9a259e66451a0b1"
+  integrity sha512-V+0z21/YNbvIX0b2Fo6mE4w5kiihrdytAwVPG66RRWvkAe4COumywRfaWrBTmVQF2aAmxoRpeyTM1LKWbiOK6Q==
 
 "@testing-library/dom@^8.5.0":
   version "8.13.0"


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

This is to add `<CustomCheckoutProvider />` component.
- bump @stripe/stripe-js version (so it has types from https://github.com/stripe/stripe-js/pull/489)
- add `<CustomCheckoutProvider />`
- add storybook example

### API review

<!-- Delete this section if this change involves no API changes. -->

Copy [this template] **or** link to an API review issue.

[this template]:
  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
- unit test
- storybook example

https://github.com/stripe/react-stripe-js/assets/65737086/45ea276b-cc44-4b50-8d0e-e07411d3e2dd

- my own demo in next.js

https://github.com/stripe/react-stripe-js/assets/65737086/c7714b52-a169-4ab2-ace7-33bfe397006a


