### PR TITLE
Throw error when CustomCheckoutContext value is null

### DIFF
--- a/src/components/CustomCheckout.tsx
+++ b/src/components/CustomCheckout.tsx
@@ -254,8 +254,14 @@ export const useElementsOrCustomCheckoutSdkContextWithUseCase = (
   return parseElementsContext(elementsContext, useCaseString);
 };
 
-export const useCustomCheckout = (): CustomCheckoutContextValue | null => {
+export const useCustomCheckout = (): CustomCheckoutContextValue => {
   // ensure it's in CustomCheckoutProvider
   useCustomCheckoutSdkContextWithUseCase('calls useCustomCheckout()');
-  return React.useContext(CustomCheckoutContext);
+  const ctx = React.useContext(CustomCheckoutContext);
+  if (!ctx) {
+    throw new Error(
+      'Could not find CustomCheckout Context; You need to wrap the part of your app that calls useCustomCheckout() in an <CustomCheckoutProvider> provider.'
+    );
+  }
+  return ctx;
 };


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->
Throw error when CustomCheckoutContext value is null
- we don't render any children until the context is set. So as long as the app is wrapped in CustomCheckoutProvider, users should not hit this error.
- This is to make it easier for TS users to destruct the object without worrying about nullable cases
### API review

<!-- Delete this section if this change involves no API changes. -->

Copy [this template] **or** link to an API review issue.

[this template]:
  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
Tested in storybook
<img width="762" alt="CleanShot 2023-09-12 at 12 03 29@2x" src="https://github.com/stripe/react-stripe-js/assets/65737086/96093676-2aeb-4fd0-b512-a7ce221f4050">
