### PR TITLE
update publish script to check for github token

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -79,6 +79,13 @@ verify_commit_is_signed() {
   fi
 }
 
+check_github_token() {
+  if [[ -z "${GITHUB_TOKEN}" ]]; then
+    echo "GITHUB_TOKEN is not set."
+    exit 1
+  fi
+}
+
 # Show help if no arguments passed
 if [ $# -eq 0 ]; then
   echo "Error! Missing release type argument"
@@ -137,6 +144,8 @@ if [ -n "$PREID" ]; then
     fi
   fi
 fi
+
+check_github_token
 
 # Make sure our working dir is the repo root directory
 cd "$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
### Summary & motivation

Adds a quick 'n easy check for our publish script to see if the GITHUB_TOKEN is set.

```
GITHUB_TOKEN="" ./scripts/publish patch
GITHUB_TOKEN is not set.
```


<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
