### PR TITLE
Add support for fetchClientSecret param to Embedded Checkout

### DIFF
--- a/src/components/EmbeddedCheckout.client.test.tsx
+++ b/src/components/EmbeddedCheckout.client.test.tsx
@@ -13,7 +13,8 @@ describe('EmbeddedCheckout on the client', () => {
   let mockEmbeddedCheckout: any;
   let mockEmbeddedCheckoutPromise: any;
   const fakeClientSecret = 'cs_123_secret_abc';
-  const fakeOptions = {clientSecret: fakeClientSecret};
+  const fetchClientSecret = () => Promise.resolve(fakeClientSecret);
+  const fakeOptions = {fetchClientSecret};
 
   beforeEach(() => {
     mockStripe = mocks.mockStripe();
@@ -73,10 +74,13 @@ describe('EmbeddedCheckout on the client', () => {
     expect(mockEmbeddedCheckout.mount).toBeCalledWith(container.firstChild);
   });
 
-  it('does not mount until Embedded Checkouts has been initialized', async () => {
+  it('does not mount until Embedded Checkout has been initialized', async () => {
     // Render with no stripe instance and client secret
     const {container, rerender} = render(
-      <EmbeddedCheckoutProvider stripe={null} options={{clientSecret: null}}>
+      <EmbeddedCheckoutProvider
+        stripe={null}
+        options={{fetchClientSecret: null}}
+      >
         <EmbeddedCheckout />
       </EmbeddedCheckoutProvider>
     );
@@ -86,18 +90,18 @@ describe('EmbeddedCheckout on the client', () => {
     rerender(
       <EmbeddedCheckoutProvider
         stripe={mockStripe}
-        options={{clientSecret: null}}
+        options={{fetchClientSecret: null}}
       >
         <EmbeddedCheckout />
       </EmbeddedCheckoutProvider>
     );
     expect(mockEmbeddedCheckout.mount).not.toBeCalled();
 
-    // Set client secret
+    // Set fetchClientSecret
     rerender(
       <EmbeddedCheckoutProvider
         stripe={mockStripe}
-        options={{clientSecret: fakeClientSecret}}
+        options={{fetchClientSecret}}
       >
         <EmbeddedCheckout />
       </EmbeddedCheckoutProvider>
@@ -153,5 +157,20 @@ describe('EmbeddedCheckout on the client', () => {
         ></EmbeddedCheckoutProvider>
       );
     }).not.toThrow();
+  });
+
+  it('still works with clientSecret param (deprecated)', async () => {
+    const {container} = render(
+      <EmbeddedCheckoutProvider
+        stripe={mockStripe}
+        options={{clientSecret: 'cs_123_456'}}
+      >
+        <EmbeddedCheckout />
+      </EmbeddedCheckoutProvider>
+    );
+
+    await act(() => mockEmbeddedCheckoutPromise);
+
+    expect(mockEmbeddedCheckout.mount).toBeCalledWith(container.firstChild);
   });
 });

--- a/src/components/EmbeddedCheckoutProvider.tsx
+++ b/src/components/EmbeddedCheckoutProvider.tsx
@@ -174,7 +174,7 @@ export const EmbeddedCheckoutProvider: FunctionComponent<PropsWithChildren<
     }
 
     if (
-      options.clientSecret === undefined ||
+      options.clientSecret === undefined &&
       options.fetchClientSecret === undefined
     ) {
       console.warn(

--- a/src/components/EmbeddedCheckoutProvider.tsx
+++ b/src/components/EmbeddedCheckoutProvider.tsx
@@ -46,11 +46,13 @@ interface EmbeddedCheckoutProviderProps {
   stripe: PromiseLike<stripeJs.Stripe | null> | stripeJs.Stripe | null;
   /**
    * Embedded Checkout configuration options.
-   * You can initially pass in `null` as `options.clientSecret` if you are
-   * performing an initial server-side render or when generating a static site.
+   * You can initially pass in `null` to `options.clientSecret` or
+   * `options.fetchClientSecret` if you are performing an initial server-side
+   * render or when generating a static site.
    */
   options: {
-    clientSecret: string | null;
+    clientSecret?: string | null;
+    fetchClientSecret?: (() => Promise<string>) | null;
     onComplete?: () => void;
   };
 }
@@ -102,7 +104,7 @@ export const EmbeddedCheckoutProvider: FunctionComponent<PropsWithChildren<
     if (
       parsed.tag === 'async' &&
       !loadedStripe.current &&
-      options.clientSecret
+      (options.clientSecret || options.fetchClientSecret)
     ) {
       parsed.stripePromise.then((stripe) => {
         if (stripe) {
@@ -112,7 +114,7 @@ export const EmbeddedCheckoutProvider: FunctionComponent<PropsWithChildren<
     } else if (
       parsed.tag === 'sync' &&
       !loadedStripe.current &&
-      options.clientSecret
+      (options.clientSecret || options.fetchClientSecret)
     ) {
       // Or, handle a sync stripe instance going from null -> populated
       setStripeAndInitEmbeddedCheckout(parsed.stripe);
@@ -172,11 +174,29 @@ export const EmbeddedCheckoutProvider: FunctionComponent<PropsWithChildren<
     }
 
     if (
+      options.clientSecret === undefined ||
+      options.fetchClientSecret === undefined
+    ) {
+      console.warn(
+        'Invalid props passed to EmbeddedCheckoutProvider: You must provide one of either `options.fetchClientSecret` or `options.clientSecret`.'
+      );
+    }
+
+    if (
       prevOptions.clientSecret != null &&
       options.clientSecret !== prevOptions.clientSecret
     ) {
       console.warn(
         'Unsupported prop change on EmbeddedCheckoutProvider: You cannot change the client secret after setting it. Unmount and create a new instance of EmbeddedCheckoutProvider instead.'
+      );
+    }
+
+    if (
+      prevOptions.fetchClientSecret != null &&
+      options.fetchClientSecret !== prevOptions.fetchClientSecret
+    ) {
+      console.warn(
+        'Unsupported prop change on EmbeddedCheckoutProvider: You cannot change fetchClientSecret after setting it. Unmount and create a new instance of EmbeddedCheckoutProvider instead.'
       );
     }
 


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Adds support for passing the `fetchClientSecret` param to `<EmbeddedCheckoutProvider>`'s `options` prop.

Example usage:

```javascript
import * as React from 'react';
import {loadStripe} from '@stripe/stripe-js';
import {
  EmbeddedCheckoutProvider,
  EmbeddedCheckout
} from '@stripe/react-stripe-js';

const stripePromise = loadStripe('pk_test_123', {betas: ['embedded_checkout_beta_1']}));

const App = ({createCheckoutSession}) => {
  const options = {
    fetchClientSecret: async () => { 
      const clientSecret = await createCheckoutSession(); 
      return clientSecret;
    }
  };

  return (
    <EmbeddedCheckoutProvider
      stripe={stripePromise}
      options={options}
    />
      <EmbeddedCheckout />
    </EmbeddedCheckoutProvider>
  )
}
```

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

Unit tests and manual testing locally.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
