### PR TITLE
Add onLoadError to card and cardNumber elements

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,10 +84,7 @@ export interface CardElementProps extends ElementProps {
   /**
    * Triggered when the Element fails to load.
    */
-  onLoadError?: (event: {
-    elementType: 'card';
-    error: StripeError;
-  }) => any;
+  onLoadError?: (event: {elementType: 'card'; error: StripeError}) => any;
 }
 
 export type CardElementComponent = FunctionComponent<CardElementProps>;
@@ -124,10 +121,7 @@ export interface CardNumberElementProps extends ElementProps {
   /**
    * Triggered when the Element fails to load.
    */
-  onLoadError?: (event: {
-    elementType: 'cardNumber';
-    error: StripeError;
-  }) => any;
+  onLoadError?: (event: {elementType: 'cardNumber'; error: StripeError}) => any;
 }
 
 export type CardNumberElementComponent = FunctionComponent<

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,14 @@ export interface CardElementProps extends ElementProps {
    * For more information, refer to the [Stripe.js reference](https://stripe.com/docs/js/element/events/on_networkschange?type=cardElement).
    */
   onNetworksChange?: (event: {elementType: 'card'}) => any;
+
+  /**
+   * Triggered when the Element fails to load.
+   */
+  onLoadError?: (event: {
+    elementType: 'card';
+    error: StripeError;
+  }) => any;
 }
 
 export type CardElementComponent = FunctionComponent<CardElementProps>;
@@ -112,6 +120,14 @@ export interface CardNumberElementProps extends ElementProps {
    * For more information, refer to the [Stripe.js reference](https://stripe.com/docs/js/element/events/on_networkschange?type=cardNumberElement).
    */
   onNetworksChange?: (event: {elementType: 'cardNumber'}) => any;
+
+  /**
+   * Triggered when the Element fails to load.
+   */
+  onLoadError?: (event: {
+    elementType: 'cardNumber';
+    error: StripeError;
+  }) => any;
 }
 
 export type CardNumberElementComponent = FunctionComponent<


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Users will now be able to use onLoadError on the card and cardNumber elements:

```
cardElement.onLoadError((e) => console.log(e));

cardNumberElement.onLoadError((e) => console.log(e));
```

### API review

<!-- Delete this section if this change involves no API changes. -->

https://docs.google.com/document/d/1ZoI--5Uuiy9j_FfEJauL9i_X5vf7miEsHIOp-2JS0eY/edit

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

I wrote unit tests

Will update the documentation when we release the feature
