### PR TITLE
Fix Storybook OpenSSL Error on Node.js v17+ by Using Legacy Provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prettier:fix": "prettier './**/*.js' './**/*.ts' './**/*.tsx' './**/*.css' './**/*.md' --write",
     "prepublishOnly": "echo \"\nPlease use ./scripts/publish instead\n\" && exit 1",
     "doctoc": "doctoc README.md",
-    "storybook": "start-storybook -p 6006 "
+    "storybook": "cross-env NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006"
   },
   "keywords": [
     "React",
@@ -81,6 +81,7 @@
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
+    "cross-env": "^7.0.3",
     "eslint": "6.6.0",
     "eslint-config-airbnb": "18.0.1",
     "eslint-config-prettier": "^6.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4926,6 +4926,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4937,7 +4944,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
### Summary & motivation
 Storybook was failing to run on Node.js v17+ due to OpenSSL breaking changes and Webpack's use of deprecated crypto functions.  Added the --openssl-legacy-provider flag to the NODE_OPTIONS in the storybook script in package.json. This ensures compatibility with newer Node.js versions without requiring a downgrade.

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a 
screenshot/GIF. -->

[this template]:
  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md

### Testing & documentation
Before making changes
```js
yarn run v1.22.22
$ start-storybook -p 6006 
info @storybook/react v6.5.0-beta.8
info 
info => Loading presets
info => Using implicit CSS loaders
(node:6375) DeprecationWarning: Default PostCSS plugins are deprecated. When switching to '@storybook/addon-postcss',
you will need to add your own plugins, such as 'postcss-flexbugs-fixes' and 'autoprefixer'.

See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-default-postcss-plugins for details.
(Use `node --trace-deprecation ...` to show where the warning was created)
info => Using default Webpack4 setup
10% building 1/4 modules 3 active ...ode_modules/babel-loader/lib/index.js??ref--4-0!/workspaces/react-stripe-js/generated-stories-entry.jsBrowserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
node:internal/crypto/hash:79
  this[kHandle] = new _Hash(algorithm, xofLen, algorithmId, getHashCache());
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:79:19)
    at Object.createHash (node:crypto:139:10)
    at module.exports (/workspaces/react-stripe-js/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/workspaces/react-stripe-js/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/workspaces/react-stripe-js/node_modules/webpack/lib/NormalModule.js:471:10)
    at /workspaces/react-stripe-js/node_modules/webpack/lib/NormalModule.js:503:5
    at /workspaces/react-stripe-js/node_modules/webpack/lib/NormalModule.js:358:12
    at /workspaces/react-stripe-js/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/workspaces/react-stripe-js/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at Array.<anonymous> (/workspaces/react-stripe-js/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
    at Storage.finished (/workspaces/react-stripe-js/node_modules/webpack/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
    at /workspaces/react-stripe-js/node_modules/webpack/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
    at /workspaces/react-stripe-js/node_modules/graceful-fs/graceful-fs.js:123:16
    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read/context:68:3) {
  opensslErrorStack: [
    'error:03000086:digital envelope routines::initialization error',
    'error:0308010C:digital envelope routines::unsupported'
  ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v20.17.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```
**After Making changes...**
Storybook runs successfully.
```js
│                                                                                          │
│   Storybook 6.5.0-beta.8 for React started                                               │
│   5.91 s for preview                                                                     │
│                                                                                          │
│    Local:            http://localhost:6006/                                              │
│    On your network:  http://10.0.3.111:6006/                                             │
│                                                                                          │
│   A new version (8.3.0) is available!                                                    │
│                                                                                          │
│   Upgrade now: npx sb@latest upgrade                                                     │
│                                                                                          │
│   Read full changelog: https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md 
```

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
