### PR TITLE
Fix lagging version in build

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -173,9 +173,6 @@ fi
 echo "Installing dependencies according to lockfile"
 yarn -s install --frozen-lockfile
 
-echo "Building"
-yarn -s run build
-
 echo "Running tests"
 yarn -s run test
 
@@ -187,6 +184,8 @@ else
   yarn -s version --$RELEASE_TYPE
 fi
 
+echo "Building"
+yarn -s run build
 
 create_github_release
 verify_commit_is_signed


### PR DESCRIPTION
### Summary & motivation

When publishing this package, our build is run before the version bump so the output artifact's version lags behind.
This change moves the build after the version bump.
Note: the test command is still run before the version bump and should catch any immediate problems with the code.