### PR TITLE
Update @stripe/stripe-js peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@types/react": "18.0.5"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": "^1.44.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+    "@stripe/stripe-js": ">=1.44.1 <7.0.0",
     "react": ">=16.8.0 <20.0.0",
     "react-dom": ">=16.8.0 <20.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "@storybook/react": "^6.5.0-beta.8",
-    "@stripe/stripe-js": "^5.0.0",
+    "@stripe/stripe-js": "^6.0.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/react-hooks": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,10 +2350,10 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
-"@stripe/stripe-js@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-5.0.0.tgz#c5fe8e8fbd94080cfd7d55e35e51939ec5c57346"
-  integrity sha512-u/f/uq7oCgHGgnSxC/I68pHpMf1XQMNBeb8mbhbxFSCji86uz4HvC50vbUS1FBTkx+b4gkTIo/UCnYjwn1cseg==
+"@stripe/stripe-js@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-6.0.0.tgz#7a2a244c133885f1694059f1f7b34536846517e7"
+  integrity sha512-Q8dbgLhXqtSCGflO8KaEQxM6/b3nHyPnX45300jxjUxS1acnBV5x7VRpWw0GDYgxAElIhlarPw0txXdeMzMC7Q==
 
 "@testing-library/dom@^8.5.0":
   version "8.13.0"


### PR DESCRIPTION
### Summary & motivation
This change updates the `@stripe/stripe-js` peer dependency in preparation for Acacia.

https://github.com/stripe/stripe-js/pull/737

### Testing & documentation
Tested on https://jubianchi.github.io/semver-check
* 1.44.1: match
* 6.0.0: match
* 6.9.9: match
* 1.44.0: no match
* 7.0.0: no match
