### PR TITLE
Fix clean publish bug

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -173,9 +173,6 @@ fi
 echo "Installing dependencies according to lockfile"
 yarn install --frozen-lockfile
 
-echo "Running tests"
-yarn run test
-
 if [ -n "$PREID" ]; then
   echo "Bumping package.json $RELEASE_TYPE, $PREID version and tagging commit"
   yarn version --$RELEASE_TYPE --preid $PREID
@@ -186,6 +183,9 @@ fi
 
 echo "Building"
 yarn run build
+
+echo "Running tests"
+yarn run test
 
 verify_commit_is_signed
 


### PR DESCRIPTION
### Summary & motivation
If the publish script is run without the `dist` folder, it fails. This commit moves the test section after the build to fix this problem.

Previously, I moved the build after the version so the new version is in the output, but I did not move the test section also. This meant the tests were running on an outdated build and would fail if a build had not been run.
