### PR TITLE
Fix issue with ignored appearance changes.

### DIFF
--- a/src/components/CheckoutProvider.tsx
+++ b/src/components/CheckoutProvider.tsx
@@ -172,17 +172,24 @@ export const CheckoutProvider: FunctionComponent<PropsWithChildren<
 
   // Apply updates to elements when options prop has relevant changes
   const prevOptions = usePrevious(options);
+  const prevCheckoutSdk = usePrevious(ctx.checkoutSdk);
   React.useEffect(() => {
+    // Ignore changes while checkout sdk is not initialized.
     if (!ctx.checkoutSdk) {
       return;
     }
 
     const previousAppearance = prevOptions?.elementsOptions?.appearance;
     const currentAppearance = options?.elementsOptions?.appearance;
-    if (currentAppearance && !isEqual(currentAppearance, previousAppearance)) {
+    const hasAppearanceChanged = !isEqual(
+      currentAppearance,
+      previousAppearance
+    );
+    const hasSdkLoaded = !prevCheckoutSdk && ctx.checkoutSdk;
+    if (currentAppearance && (hasAppearanceChanged || hasSdkLoaded)) {
       ctx.checkoutSdk.changeAppearance(currentAppearance);
     }
-  }, [options, prevOptions, ctx.checkoutSdk]);
+  }, [options, prevOptions, ctx.checkoutSdk, prevCheckoutSdk]);
 
   // Attach react-stripe-js version to stripe.js instance
   React.useEffect(() => {


### PR DESCRIPTION
### Summary & motivation

This fixes an bug where Appearance API updates that get made before the Checkout SDK is ready get ignored forever.



### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
