### PR TITLE
Update docs link Elements.tsx

### DIFF
--- a/src/components/Elements.tsx
+++ b/src/components/Elements.tsx
@@ -72,7 +72,7 @@ interface PrivateElementsProps {
  * The `loadStripe` function will asynchronously load the Stripe.js script and initialize a `Stripe` object.
  * Pass the returned `Promise` to `Elements`.
  *
- * @docs https://stripe.com/docs/stripe-js/react#elements-provider
+ * @docs https://docs.stripe.com/sdks/stripejs-react?ui=elements#elements-provider
  */
 export const Elements: FunctionComponent<PropsWithChildren<ElementsProps>> = (({
   stripe: rawStripeProp,


### PR DESCRIPTION
### Summary

Updates docs link in `Elements.tsx` to point to:

- https://docs.stripe.com/sdks/stripejs-react?ui=elements#elements-provider