### PR TITLE
feat: load fonts when they change

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "@storybook/react": "^6.5.0-beta.8",
-    "@stripe/stripe-js": "^7.6.1",
+    "@stripe/stripe-js": "^7.8.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/react-hooks": "^8.0.0",

--- a/src/components/CheckoutProvider.test.tsx
+++ b/src/components/CheckoutProvider.test.tsx
@@ -296,6 +296,135 @@ describe('CheckoutProvider', () => {
     });
   });
 
+  test('it does not call loadFonts a 2nd time if they do not change', async () => {
+    let result: any;
+    const fetchClientSecret = async () => 'cs_123';
+    act(() => {
+      result = render(
+        <CheckoutProvider
+          stripe={mockStripe}
+          options={{
+            fetchClientSecret,
+            elementsOptions: {
+              fonts: [
+                {
+                  cssSrc: 'https://example.com/font.css',
+                },
+              ],
+            },
+          }}
+        />
+      );
+    });
+
+    await waitFor(() =>
+      expect(mockStripe.initCheckout).toHaveBeenCalledWith({
+        fetchClientSecret,
+        elementsOptions: {
+          fonts: [
+            {
+              cssSrc: 'https://example.com/font.css',
+            },
+          ],
+        },
+      })
+    );
+
+    act(() => {
+      result.rerender(
+        <CheckoutProvider
+          stripe={mockStripe}
+          options={{
+            fetchClientSecret: async () => 'cs_123',
+            elementsOptions: {
+              fonts: [
+                {
+                  cssSrc: 'https://example.com/font.css',
+                },
+              ],
+            },
+          }}
+        />
+      );
+    });
+
+    act(() => {
+      result.rerender(
+        <CheckoutProvider
+          stripe={mockStripe}
+          options={{
+            fetchClientSecret: async () => 'cs_123',
+            elementsOptions: {
+              fonts: [
+                {
+                  cssSrc: 'https://example.com/font.css',
+                },
+              ],
+            },
+          }}
+        />
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockStripe.initCheckout).toHaveBeenCalledTimes(1);
+
+      // This is called once, due to the sdk having loaded.
+      expect(mockCheckoutSdk.loadFonts).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('allows changes to elementsOptions fonts', async () => {
+    let result: any;
+    const fetchClientSecret = async () => 'cs_123';
+    act(() => {
+      result = render(
+        <CheckoutProvider
+          stripe={mockStripe}
+          options={{
+            fetchClientSecret,
+            elementsOptions: {},
+          }}
+        />
+      );
+    });
+
+    await waitFor(() =>
+      expect(mockStripe.initCheckout).toHaveBeenCalledWith({
+        fetchClientSecret,
+        elementsOptions: {},
+      })
+    );
+
+    act(() => {
+      result.rerender(
+        <CheckoutProvider
+          stripe={mockStripe}
+          options={{
+            fetchClientSecret: async () => 'cs_123',
+            elementsOptions: {
+              fonts: [
+                {
+                  cssSrc: 'https://example.com/font.css',
+                },
+              ],
+            },
+          }}
+        />
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockStripe.initCheckout).toHaveBeenCalledTimes(1);
+      expect(mockCheckoutSdk.loadFonts).toHaveBeenCalledTimes(1);
+      expect(mockCheckoutSdk.loadFonts).toHaveBeenCalledWith([
+        {
+          cssSrc: 'https://example.com/font.css',
+        },
+      ]);
+    });
+  });
+
   test('allows options changes before setting the Stripe object', async () => {
     let result: any;
     const fetchClientSecret = async () => 'cs_123';

--- a/src/components/CheckoutProvider.tsx
+++ b/src/components/CheckoutProvider.tsx
@@ -198,7 +198,6 @@ export const CheckoutProvider: FunctionComponent<PropsWithChildren<
     const hasFontsChanged = !isEqual(previousFonts, currentFonts);
 
     if (currentFonts && (hasFontsChanged || hasSdkLoaded)) {
-      // @ts-expect-error - Remove me before merging!
       ctx.checkoutSdk.loadFonts(currentFonts);
     }
   }, [options, prevOptions, ctx.checkoutSdk, prevCheckoutSdk]);

--- a/src/components/CheckoutProvider.tsx
+++ b/src/components/CheckoutProvider.tsx
@@ -179,15 +179,27 @@ export const CheckoutProvider: FunctionComponent<PropsWithChildren<
       return;
     }
 
+    const hasSdkLoaded = Boolean(!prevCheckoutSdk && ctx.checkoutSdk);
+
+    // Handle appearance changes
     const previousAppearance = prevOptions?.elementsOptions?.appearance;
     const currentAppearance = options?.elementsOptions?.appearance;
     const hasAppearanceChanged = !isEqual(
       currentAppearance,
       previousAppearance
     );
-    const hasSdkLoaded = !prevCheckoutSdk && ctx.checkoutSdk;
     if (currentAppearance && (hasAppearanceChanged || hasSdkLoaded)) {
       ctx.checkoutSdk.changeAppearance(currentAppearance);
+    }
+
+    // Handle fonts changes
+    const previousFonts = prevOptions?.elementsOptions?.fonts;
+    const currentFonts = options?.elementsOptions?.fonts;
+    const hasFontsChanged = !isEqual(previousFonts, currentFonts);
+
+    if (currentFonts && (hasFontsChanged || hasSdkLoaded)) {
+      // @ts-expect-error - Remove me before merging!
+      ctx.checkoutSdk.loadFonts(currentFonts);
     }
   }, [options, prevOptions, ctx.checkoutSdk, prevCheckoutSdk]);
 

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -42,6 +42,7 @@ export const mockCheckoutSdk = () => {
 
   return {
     changeAppearance: jest.fn(),
+    loadFonts: jest.fn(),
     createPaymentElement: jest.fn(() => {
       elements.payment = mockElement();
       return elements.payment;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,10 +2350,10 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
-"@stripe/stripe-js@^7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-7.6.1.tgz#0e57dc68115eb7bca9b526962e89533852ca2153"
-  integrity sha512-BUDj5gujbtx53/Cexws0+aPrEBsKAN8ExPf9UfuTCivVU6ug2PjqI0zUeL1jon3795eOLlyqvCDjp6VNknjE0A==
+"@stripe/stripe-js@^7.8.0":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-7.8.0.tgz#01390d31030f04b64a7ff13adcccbafd615c7b77"
+  integrity sha512-DNXRfYUgkZlrniQORbA/wH8CdFRhiBSE0R56gYU0V5vvpJ9WZwvGrz9tBAZmfq2aTgw6SK7mNpmTizGzLWVezw==
 
 "@testing-library/dom@^8.5.0":
   version "8.13.0"


### PR DESCRIPTION
### Summary & motivation

When `elementsOptions.fonts` is updated in `CheckoutProvider`, we update Elements accordingly with any new fonts.

### API review

Internal Stripe API review.

<!-- Delete this section if this change involves no API changes. -->

Copy [this template] **or** link to an API review issue.

[this template]:
  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md

### Testing & documentation

Wrote unit tests.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
