### PR TITLE
[breaking] Update useCheckout to return loading/error states

### DIFF
--- a/src/components/CheckoutProvider.test.tsx
+++ b/src/components/CheckoutProvider.test.tsx
@@ -6,6 +6,7 @@ import {CheckoutProvider, useCheckout} from './CheckoutProvider';
 import {Elements} from './Elements';
 import {useStripe} from './useStripe';
 import * as mocks from '../../test/mocks';
+import makeDeferred from '../../test/makeDeferred';
 
 describe('CheckoutProvider', () => {
   let mockStripe: any;
@@ -38,122 +39,114 @@ describe('CheckoutProvider', () => {
     jest.restoreAllMocks();
   });
 
-  test('injects CheckoutProvider with the useCheckout hook', async () => {
-    const wrapper = ({children}: any) => (
-      <CheckoutProvider
-        stripe={mockStripe}
-        options={{fetchClientSecret: async () => 'cs_123'}}
-      >
-        {children}
-      </CheckoutProvider>
-    );
+  const makeFetchClientSecret = () => async () => {
+    return 'cs_123';
+  };
 
-    const {result, waitForNextUpdate} = renderHook(() => useCheckout(), {
-      wrapper,
+  const wrapper = ({stripe, fetchClientSecret, children}: any) => (
+    <CheckoutProvider
+      stripe={stripe === undefined ? mockStripe : stripe}
+      options={{
+        fetchClientSecret: fetchClientSecret || makeFetchClientSecret(),
+      }}
+    >
+      {children}
+    </CheckoutProvider>
+  );
+
+  describe('interaction with useStripe()', () => {
+    it('works with a Stripe instance', async () => {
+      const {result, waitForNextUpdate} = renderHook(() => useStripe(), {
+        wrapper,
+        initialProps: {stripe: mockStripe},
+      });
+
+      expect(result.current).toBe(mockStripe);
+
+      await waitForNextUpdate();
+
+      expect(result.current).toBe(mockStripe);
     });
 
-    // observe intermediate states
-    await waitForNextUpdate();
+    it('works when updating null to a Stripe instance', async () => {
+      const {result, rerender, waitForNextUpdate} = renderHook(
+        () => useStripe(),
+        {
+          wrapper,
+          initialProps: {stripe: null},
+        }
+      );
 
-    // wait for all (potentially multiple) updates to finish
-    await waitFor(() => expect(result.current).toEqual(mockCheckout));
-  });
+      expect(result.current).toBe(null);
 
-  test('injects CheckoutProvider with the useStripe hook', async () => {
-    const wrapper = ({children}: any) => (
-      <CheckoutProvider
-        stripe={mockStripe}
-        options={{fetchClientSecret: async () => 'cs_123'}}
-      >
-        {children}
-      </CheckoutProvider>
-    );
+      rerender({stripe: mockStripe});
+      await waitForNextUpdate();
 
-    const {result, waitForNextUpdate} = renderHook(() => useStripe(), {
-      wrapper,
+      expect(result.current).toBe(mockStripe);
     });
 
-    // observe intermediate states
-    await waitForNextUpdate();
+    it('works with a Promise', async () => {
+      const deferred = makeDeferred();
+      const {result} = renderHook(() => useStripe(), {
+        wrapper,
+        initialProps: {stripe: deferred.promise},
+      });
 
-    // wait for all (potentially multiple) updates to finish
-    await waitFor(() => expect(result.current).toBe(mockStripe));
+      expect(result.current).toBe(null);
+
+      await act(() => deferred.resolve(mockStripe));
+
+      expect(result.current).toBe(mockStripe);
+    });
   });
 
-  test('allows a transition from null to a valid Stripe object', async () => {
-    let stripeProp: any = null;
-    const wrapper = ({children}: any) => (
-      <CheckoutProvider
-        stripe={stripeProp}
-        options={{fetchClientSecret: async () => 'cs_123'}}
-      >
-        {children}
-      </CheckoutProvider>
-    );
+  describe('interaction with useCheckout()', () => {
+    it('works when initCheckout resolves', async () => {
+      const stripe: any = mocks.mockStripe();
+      const deferred = makeDeferred();
+      stripe.initCheckout.mockReturnValue(deferred.promise);
 
-    const {result, rerender} = renderHook(() => useCheckout(), {wrapper});
-    expect(result.current).toBe(undefined);
+      const {result} = renderHook(() => useCheckout(), {
+        wrapper,
+        initialProps: {stripe},
+      });
 
-    stripeProp = mockStripe;
-    act(() => rerender());
-    await waitFor(() => expect(result.current).toEqual(mockCheckout));
-  });
+      expect(result.current).toEqual({type: 'loading'});
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
 
-  test('works with a Promise resolving to a valid Stripe object', async () => {
-    const wrapper = ({children}: any) => (
-      <CheckoutProvider
-        stripe={mockStripePromise}
-        options={{fetchClientSecret: async () => 'cs_123'}}
-      >
-        {children}
-      </CheckoutProvider>
-    );
+      await act(() => deferred.resolve(mockCheckoutSdk));
 
-    const {result, waitForNextUpdate} = renderHook(() => useCheckout(), {
-      wrapper,
+      expect(result.current).toEqual({
+        type: 'success',
+        checkout: mockCheckout,
+      });
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
     });
 
-    expect(result.current).toBe(undefined);
+    it('works when initCheckout rejects', async () => {
+      const stripe: any = mocks.mockStripe();
+      const deferred = makeDeferred();
+      stripe.initCheckout.mockReturnValue(deferred.promise);
 
-    await waitForNextUpdate();
+      const {result} = renderHook(() => useCheckout(), {
+        wrapper,
+        initialProps: {stripe},
+      });
 
-    await waitFor(() => expect(result.current).toEqual(mockCheckout));
-  });
+      expect(result.current).toEqual({type: 'loading'});
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
 
-  test('allows a transition from null to a valid Promise', async () => {
-    let stripeProp: any = null;
-    const wrapper = ({children}: any) => (
-      <CheckoutProvider
-        stripe={stripeProp}
-        options={{fetchClientSecret: async () => 'cs_123'}}
-      >
-        {children}
-      </CheckoutProvider>
-    );
+      await act(() => deferred.reject(new Error('initCheckout error')));
 
-    const {result, rerender, waitForNextUpdate} = renderHook(
-      () => useCheckout(),
-      {wrapper}
-    );
-    expect(result.current).toBe(undefined);
+      expect(result.current).toEqual({
+        type: 'error',
+        error: new Error('initCheckout error'),
+      });
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
+    });
 
-    stripeProp = mockStripePromise;
-    act(() => rerender());
-
-    expect(result.current).toBe(undefined);
-
-    await waitForNextUpdate();
-
-    await waitFor(() => expect(result.current).toEqual(mockCheckout));
-  });
-
-  test('does not set context if Promise resolves after CheckoutProvider is unmounted', async () => {
-    // Silence console output so test output is less noisy
-    consoleError.mockImplementation(() => {});
-
-    let result: any;
-    act(() => {
-      result = render(
+    it('does not set context if Promise resolves after CheckoutProvider is unmounted', async () => {
+      const result = render(
         <CheckoutProvider
           stripe={mockStripePromise}
           options={{fetchClientSecret: async () => 'cs_123'}}
@@ -161,50 +154,20 @@ describe('CheckoutProvider', () => {
           {null}
         </CheckoutProvider>
       );
+
+      result.unmount();
+      await act(() => mockStripePromise);
+
+      expect(consoleError).not.toHaveBeenCalled();
     });
-
-    result.unmount();
-    await act(() => mockStripePromise);
-
-    expect(consoleError).not.toHaveBeenCalled();
   });
 
-  test('works with a Promise resolving to null for SSR safety', async () => {
-    const nullPromise = Promise.resolve(null);
-    const TestComponent = () => {
-      const customCheckout = useCheckout();
-      return customCheckout ? <div>not empty</div> : null;
-    };
-
-    let result: any;
-    act(() => {
-      result = render(
-        <CheckoutProvider
-          stripe={nullPromise}
-          options={{fetchClientSecret: async () => 'cs_123'}}
-        >
-          <TestComponent />
-        </CheckoutProvider>
-      );
-    });
-
-    expect(result.container).toBeEmptyDOMElement();
-
-    await act(() => nullPromise.then(() => undefined));
-    expect(result.container).toBeEmptyDOMElement();
-  });
-
-  describe.each([
-    ['undefined', undefined],
-    ['false', false],
-    ['string', 'foo'],
-    ['random object', {foo: 'bar'}],
-  ])('invalid stripe prop', (name, stripeProp) => {
-    test(`errors when props.stripe is ${name}`, () => {
+  describe('stripe prop', () => {
+    it('validates stripe prop type', async () => {
       // Silence console output so test output is less noisy
       consoleError.mockImplementation(() => {});
 
-      expect(() =>
+      const renderWithProp = (stripeProp: unknown) => () => {
         render(
           <CheckoutProvider
             stripe={stripeProp as any}
@@ -212,68 +175,181 @@ describe('CheckoutProvider', () => {
           >
             <div />
           </CheckoutProvider>
-        )
-      ).toThrow('Invalid prop `stripe` supplied to `CheckoutProvider`.');
+        );
+      };
+
+      expect(renderWithProp(undefined)).toThrow(
+        'Invalid prop `stripe` supplied to `CheckoutProvider`.'
+      );
+      expect(renderWithProp(false)).toThrow(
+        'Invalid prop `stripe` supplied to `CheckoutProvider`.'
+      );
+      expect(renderWithProp('foo')).toThrow(
+        'Invalid prop `stripe` supplied to `CheckoutProvider`.'
+      );
+      expect(renderWithProp({foo: 'bar'})).toThrow(
+        'Invalid prop `stripe` supplied to `CheckoutProvider`.'
+      );
+    });
+
+    it('when stripe prop changes from null to a Stripe instance', async () => {
+      const stripe: any = mocks.mockStripe();
+      const deferred = makeDeferred();
+      stripe.initCheckout.mockReturnValue(deferred.promise);
+
+      const {result, rerender} = renderHook(() => useCheckout(), {
+        wrapper,
+        initialProps: {stripe: null},
+      });
+
+      expect(result.current).toEqual({type: 'loading'});
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(0);
+
+      rerender({stripe});
+
+      expect(result.current).toEqual({type: 'loading'});
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
+
+      await act(() => deferred.resolve(mockCheckoutSdk));
+
+      expect(result.current).toEqual({
+        type: 'success',
+        checkout: mockCheckout,
+      });
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
+    });
+
+    it('when the stripe prop is a Promise', async () => {
+      const stripe: any = mocks.mockStripe();
+      const stripeDeferred = makeDeferred();
+      const deferred = makeDeferred();
+      stripe.initCheckout.mockReturnValue(deferred.promise);
+
+      const {result} = renderHook(() => useCheckout(), {
+        wrapper,
+        initialProps: {stripe: stripeDeferred.promise},
+      });
+
+      expect(result.current).toEqual({type: 'loading'});
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(0);
+
+      await act(() => stripeDeferred.resolve(stripe));
+
+      expect(result.current).toEqual({type: 'loading'});
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
+
+      await act(() => deferred.resolve(mockCheckoutSdk));
+
+      expect(result.current).toEqual({
+        type: 'success',
+        checkout: mockCheckout,
+      });
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
+    });
+
+    it('when the stripe prop changes from null to a Promise', async () => {
+      const stripe: any = mocks.mockStripe();
+      const stripeDeferred = makeDeferred();
+      const deferred = makeDeferred();
+      stripe.initCheckout.mockReturnValue(deferred.promise);
+
+      const {result, rerender} = renderHook(() => useCheckout(), {
+        wrapper,
+        initialProps: {stripe: null},
+      });
+
+      expect(result.current).toEqual({type: 'loading'});
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(0);
+
+      rerender({stripe});
+
+      expect(result.current).toEqual({type: 'loading'});
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
+
+      await act(() => stripeDeferred.resolve(stripe));
+
+      expect(result.current).toEqual({type: 'loading'});
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
+
+      await act(() => deferred.resolve(mockCheckoutSdk));
+
+      expect(result.current).toEqual({
+        type: 'success',
+        checkout: mockCheckout,
+      });
+      expect(stripe.initCheckout).toHaveBeenCalledTimes(1);
+    });
+
+    it('when the stripe prop is a Promise(null)', async () => {
+      const stripeDeferred = makeDeferred<any>();
+
+      const {result} = renderHook(() => useCheckout(), {
+        wrapper,
+        initialProps: {stripe: stripeDeferred.promise},
+      });
+
+      expect(result.current).toEqual({type: 'loading'});
+
+      await act(() => stripeDeferred.resolve(null));
+
+      expect(result.current).toEqual({type: 'loading'});
+    });
+
+    it('does not allow changes to an already set Stripe object', async () => {
+      // Silence console output so test output is less noisy
+      consoleWarn.mockImplementation(() => {});
+      let result: any;
+      act(() => {
+        result = render(
+          <CheckoutProvider
+            stripe={mockStripe}
+            options={{fetchClientSecret: async () => 'cs_123'}}
+          />
+        );
+      });
+
+      const mockStripe2: any = mocks.mockStripe();
+      act(() => {
+        result.rerender(
+          <CheckoutProvider
+            stripe={mockStripe2}
+            options={{fetchClientSecret: async () => 'cs_123'}}
+          />
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockStripe.initCheckout).toHaveBeenCalledTimes(1);
+        expect(mockStripe2.initCheckout).toHaveBeenCalledTimes(0);
+        expect(consoleWarn).toHaveBeenCalledWith(
+          'Unsupported prop change on CheckoutProvider: You cannot change the `stripe` prop after setting it.'
+        );
+      });
     });
   });
 
-  test('does not allow changes to an already set Stripe object', async () => {
-    // Silence console output so test output is less noisy
-    consoleWarn.mockImplementation(() => {});
-    let result: any;
-    act(() => {
-      result = render(
-        <CheckoutProvider
-          stripe={mockStripe}
-          options={{fetchClientSecret: async () => 'cs_123'}}
-        />
-      );
-    });
-
-    const mockStripe2: any = mocks.mockStripe();
-    act(() => {
-      result.rerender(
-        <CheckoutProvider
-          stripe={mockStripe2}
-          options={{fetchClientSecret: async () => 'cs_123'}}
-        />
-      );
-    });
+  it('only calls initCheckout once and allows changes to elementsOptions appearance after setting the Stripe object', async () => {
+    const fetchClientSecret = async () => 'cs_123';
+    const result = render(
+      <CheckoutProvider
+        stripe={mockStripe}
+        options={{
+          fetchClientSecret,
+          elementsOptions: {
+            appearance: {theme: 'stripe'},
+          },
+        }}
+      />
+    );
 
     await waitFor(() => {
-      expect(mockStripe.initCheckout).toHaveBeenCalledTimes(1);
-      expect(mockStripe2.initCheckout).toHaveBeenCalledTimes(0);
-      expect(consoleWarn).toHaveBeenCalledWith(
-        'Unsupported prop change on CheckoutProvider: You cannot change the `stripe` prop after setting it.'
-      );
-    });
-  });
-
-  test('initCheckout only called once and allows changes to elementsOptions appearance after setting the Stripe object', async () => {
-    let result: any;
-    const fetchClientSecret = async () => 'cs_123';
-    act(() => {
-      result = render(
-        <CheckoutProvider
-          stripe={mockStripe}
-          options={{
-            fetchClientSecret,
-            elementsOptions: {
-              appearance: {theme: 'stripe'},
-            },
-          }}
-        />
-      );
-    });
-
-    await waitFor(() =>
       expect(mockStripe.initCheckout).toHaveBeenCalledWith({
         fetchClientSecret,
         elementsOptions: {
           appearance: {theme: 'stripe'},
         },
-      })
-    );
+      });
+    });
 
     act(() => {
       result.rerender(
@@ -425,22 +501,19 @@ describe('CheckoutProvider', () => {
     });
   });
 
-  test('allows options changes before setting the Stripe object', async () => {
-    let result: any;
+  it('allows options changes before setting the Stripe object', async () => {
     const fetchClientSecret = async () => 'cs_123';
-    act(() => {
-      result = render(
-        <CheckoutProvider
-          stripe={null}
-          options={{
-            fetchClientSecret,
-            elementsOptions: {
-              appearance: {theme: 'stripe'},
-            },
-          }}
-        />
-      );
-    });
+    const result = render(
+      <CheckoutProvider
+        stripe={null}
+        options={{
+          fetchClientSecret,
+          elementsOptions: {
+            appearance: {theme: 'stripe'},
+          },
+        }}
+      />
+    );
 
     await waitFor(() =>
       expect(mockStripe.initCheckout).toHaveBeenCalledTimes(0)
@@ -468,66 +541,6 @@ describe('CheckoutProvider', () => {
         },
       });
     });
-  });
-
-  test('throws when trying to call useCheckout outside of CheckoutProvider context', () => {
-    const {result} = renderHook(() => useCheckout());
-
-    expect(result.error && result.error.message).toBe(
-      'Could not find CheckoutProvider context; You need to wrap the part of your app that calls useCheckout() in an <CheckoutProvider> provider.'
-    );
-  });
-
-  test('throws when trying to call useStripe outside of CheckoutProvider context', () => {
-    const {result} = renderHook(() => useStripe());
-
-    expect(result.error && result.error.message).toBe(
-      'Could not find Elements context; You need to wrap the part of your app that calls useStripe() in an <Elements> provider.'
-    );
-  });
-
-  test('throws when trying to call useStripe in Elements -> CheckoutProvider nested context', async () => {
-    const wrapper = ({children}: any) => (
-      <Elements stripe={mockStripe}>
-        <CheckoutProvider
-          stripe={mockStripe}
-          options={{fetchClientSecret: async () => 'cs_123'}}
-        >
-          {children}
-        </CheckoutProvider>
-      </Elements>
-    );
-
-    const {result, waitForNextUpdate} = renderHook(() => useStripe(), {
-      wrapper,
-    });
-
-    await waitForNextUpdate();
-
-    expect(result.error && result.error.message).toBe(
-      'You cannot wrap the part of your app that calls useStripe() in both <CheckoutProvider> and <Elements> providers.'
-    );
-  });
-
-  test('throws when trying to call useStripe in CheckoutProvider -> Elements nested context', async () => {
-    const wrapper = ({children}: any) => (
-      <CheckoutProvider
-        stripe={mockStripe}
-        options={{fetchClientSecret: async () => 'cs_123'}}
-      >
-        <Elements stripe={mockStripe}>{children}</Elements>
-      </CheckoutProvider>
-    );
-
-    const {result, waitForNextUpdate} = renderHook(() => useStripe(), {
-      wrapper,
-    });
-
-    await waitForNextUpdate();
-
-    expect(result.error && result.error.message).toBe(
-      'You cannot wrap the part of your app that calls useStripe() in both <CheckoutProvider> and <Elements> providers.'
-    );
   });
 
   describe('React.StrictMode', () => {
@@ -628,6 +641,63 @@ describe('CheckoutProvider', () => {
           theme: 'night',
         });
       });
+    });
+  });
+
+  describe('providers <> hooks', () => {
+    it('throws when trying to call useCheckout outside of CheckoutProvider context', () => {
+      const {result} = renderHook(() => useCheckout());
+
+      expect(result.error && result.error.message).toBe(
+        'Could not find CheckoutProvider context; You need to wrap the part of your app that calls useCheckout() in a <CheckoutProvider> provider.'
+      );
+    });
+
+    it('throws when trying to call useStripe outside of CheckoutProvider context', () => {
+      const {result} = renderHook(() => useStripe());
+
+      expect(result.error && result.error.message).toBe(
+        'Could not find Elements context; You need to wrap the part of your app that calls useStripe() in an <Elements> provider.'
+      );
+    });
+
+    it('throws when trying to call useStripe in Elements -> CheckoutProvider nested context', async () => {
+      const wrapper = ({children}: any) => (
+        <Elements stripe={mockStripe}>
+          <CheckoutProvider
+            stripe={mockStripe}
+            options={{fetchClientSecret: async () => 'cs_123'}}
+          >
+            {children}
+          </CheckoutProvider>
+        </Elements>
+      );
+
+      const {result} = renderHook(() => useStripe(), {
+        wrapper,
+      });
+
+      expect(result.error && result.error.message).toBe(
+        'You cannot wrap the part of your app that calls useStripe() in both <CheckoutProvider> and <Elements> providers.'
+      );
+    });
+
+    it('throws when trying to call useStripe in CheckoutProvider -> Elements nested context', async () => {
+      const wrapper = ({children}: any) => (
+        <CheckoutProvider
+          stripe={mockStripe}
+          options={{fetchClientSecret: async () => 'cs_123'}}
+        >
+          <Elements stripe={mockStripe}>{children}</Elements>
+        </CheckoutProvider>
+      );
+
+      const {result} = renderHook(() => useStripe(), {
+        wrapper,
+      });
+      expect(result.error && result.error.message).toBe(
+        'You cannot wrap the part of your app that calls useStripe() in both <CheckoutProvider> and <Elements> providers.'
+      );
     });
   });
 });

--- a/src/components/CheckoutProvider.tsx
+++ b/src/components/CheckoutProvider.tsx
@@ -14,26 +14,34 @@ import {
 } from './Elements';
 import {registerWithStripeJs} from '../utils/registerWithStripeJs';
 
-interface CheckoutSdkContextValue {
-  checkoutSdk: stripeJs.StripeCheckout | null;
+export type CheckoutValue = StripeCheckoutActions &
+  stripeJs.StripeCheckoutSession;
+
+export type CheckoutState =
+  | {type: 'loading'}
+  | {
+      type: 'success';
+      checkout: CheckoutValue;
+    }
+  | {type: 'error'; error: {message: string}};
+
+type CheckoutContextValue = {
   stripe: stripeJs.Stripe | null;
-}
+  checkoutState: CheckoutState;
+};
 
-const CheckoutSdkContext = React.createContext<CheckoutSdkContextValue | null>(
-  null
-);
-CheckoutSdkContext.displayName = 'CheckoutSdkContext';
+const CheckoutContext = React.createContext<CheckoutContextValue | null>(null);
+CheckoutContext.displayName = 'CheckoutContext';
 
-export const parseCheckoutSdkContext = (
-  ctx: CheckoutSdkContextValue | null,
+const validateCheckoutContext = (
+  ctx: CheckoutContextValue | null,
   useCase: string
-): CheckoutSdkContextValue => {
+): CheckoutContextValue => {
   if (!ctx) {
     throw new Error(
-      `Could not find CheckoutProvider context; You need to wrap the part of your app that ${useCase} in an <CheckoutProvider> provider.`
+      `Could not find CheckoutProvider context; You need to wrap the part of your app that ${useCase} in a <CheckoutProvider> provider.`
     );
   }
-
   return ctx;
 };
 
@@ -42,26 +50,23 @@ type StripeCheckoutActions = Omit<
   'on'
 >;
 
-export interface CheckoutContextValue
-  extends StripeCheckoutActions,
-    stripeJs.StripeCheckoutSession {}
-const CheckoutContext = React.createContext<CheckoutContextValue | null>(null);
-CheckoutContext.displayName = 'CheckoutContext';
-
-export const extractCheckoutContextValue = (
-  checkoutSdk: stripeJs.StripeCheckout | null,
-  sessionState: stripeJs.StripeCheckoutSession | null
-): CheckoutContextValue | null => {
-  if (!checkoutSdk) {
-    return null;
+const getContextValue = (
+  stripe: stripeJs.Stripe | null,
+  state: State
+): CheckoutContextValue => {
+  if (state.type === 'success') {
+    const {sdk, session} = state;
+    const {on: _on, session: _session, ...actions} = sdk;
+    return {
+      stripe,
+      checkoutState: {
+        type: 'success',
+        checkout: Object.assign({}, session, actions),
+      },
+    };
+  } else {
+    return {stripe, checkoutState: state};
   }
-
-  const {on: _on, session: _session, ...actions} = checkoutSdk;
-  if (!sessionState) {
-    return Object.assign(checkoutSdk.session(), actions);
-  }
-
-  return Object.assign(sessionState, actions);
 };
 
 interface CheckoutProviderProps {
@@ -84,6 +89,23 @@ interface PrivateCheckoutProviderProps {
 const INVALID_STRIPE_ERROR =
   'Invalid prop `stripe` supplied to `CheckoutProvider`. We recommend using the `loadStripe` utility from `@stripe/stripe-js`. See https://stripe.com/docs/stripe-js/react#elements-props-stripe for details.';
 
+type State =
+  | {type: 'loading'}
+  | {
+      type: 'success';
+      sdk: stripeJs.StripeCheckout;
+      session: stripeJs.StripeCheckoutSession;
+    }
+  | {type: 'error'; error: {message: string}};
+
+const maybeSdk = (state: State): stripeJs.StripeCheckout | null => {
+  if (state.type === 'success') {
+    return state.sdk;
+  } else {
+    return null;
+  }
+};
+
 export const CheckoutProvider: FunctionComponent<PropsWithChildren<
   CheckoutProviderProps
 >> = (({
@@ -96,29 +118,8 @@ export const CheckoutProvider: FunctionComponent<PropsWithChildren<
     [rawStripeProp]
   );
 
-  // State used to trigger a re-render when sdk.session is updated
-  const [
-    session,
-    setSession,
-  ] = React.useState<stripeJs.StripeCheckoutSession | null>(null);
-
-  const [ctx, setContext] = React.useState<CheckoutSdkContextValue>(() => ({
-    stripe: parsed.tag === 'sync' ? parsed.stripe : null,
-    checkoutSdk: null,
-  }));
-
-  const safeSetContext = (
-    stripe: stripeJs.Stripe,
-    checkoutSdk: stripeJs.StripeCheckout
-  ) => {
-    setContext((ctx) => {
-      if (ctx.stripe && ctx.checkoutSdk) {
-        return ctx;
-      }
-
-      return {stripe, checkoutSdk};
-    });
-  };
+  const [state, setState] = React.useState<State>({type: 'loading'});
+  const [stripe, setStripe] = React.useState<stripeJs.Stripe | null>(null);
 
   // Ref used to avoid calling initCheckout multiple times when options changes
   const initCheckoutCalledRef = React.useRef(false);
@@ -126,39 +127,56 @@ export const CheckoutProvider: FunctionComponent<PropsWithChildren<
   React.useEffect(() => {
     let isMounted = true;
 
-    if (parsed.tag === 'async' && !ctx.stripe) {
+    const init = ({stripe}: {stripe: stripeJs.Stripe}) => {
+      if (stripe && isMounted && !initCheckoutCalledRef.current) {
+        // Only update context if the component is still mounted
+        // and stripe is not null. We allow stripe to be null to make
+        // handling SSR easier.
+        initCheckoutCalledRef.current = true;
+        stripe.initCheckout(options).then(
+          (sdk) => {
+            setState({type: 'success', sdk, session: sdk.session()});
+            sdk.on('change', (session) => {
+              setState((prevState) => {
+                if (prevState.type === 'success') {
+                  return {
+                    type: 'success',
+                    sdk: prevState.sdk,
+                    session,
+                  };
+                } else {
+                  return prevState;
+                }
+              });
+            });
+          },
+          (error) => {
+            setState({type: 'error', error});
+          }
+        );
+      }
+    };
+
+    if (parsed.tag === 'async') {
       parsed.stripePromise.then((stripe) => {
-        if (stripe && isMounted && !initCheckoutCalledRef.current) {
+        setStripe(stripe);
+        if (stripe) {
+          init({stripe});
+        } else {
           // Only update context if the component is still mounted
           // and stripe is not null. We allow stripe to be null to make
           // handling SSR easier.
-          initCheckoutCalledRef.current = true;
-          stripe.initCheckout(options).then((checkoutSdk) => {
-            if (checkoutSdk) {
-              safeSetContext(stripe, checkoutSdk);
-              checkoutSdk.on('change', setSession);
-            }
-          });
         }
       });
-    } else if (
-      parsed.tag === 'sync' &&
-      parsed.stripe &&
-      !initCheckoutCalledRef.current
-    ) {
-      initCheckoutCalledRef.current = true;
-      parsed.stripe.initCheckout(options).then((checkoutSdk) => {
-        if (checkoutSdk) {
-          safeSetContext(parsed.stripe, checkoutSdk);
-          checkoutSdk.on('change', setSession);
-        }
-      });
+    } else if (parsed.tag === 'sync') {
+      setStripe(parsed.stripe);
+      init({stripe: parsed.stripe});
     }
 
     return () => {
       isMounted = false;
     };
-  }, [parsed, ctx, options, setSession]);
+  }, [parsed, options, setState]);
 
   // Warn on changes to stripe prop
   const prevStripe = usePrevious(rawStripeProp);
@@ -171,15 +189,16 @@ export const CheckoutProvider: FunctionComponent<PropsWithChildren<
   }, [prevStripe, rawStripeProp]);
 
   // Apply updates to elements when options prop has relevant changes
+  const sdk = maybeSdk(state);
   const prevOptions = usePrevious(options);
-  const prevCheckoutSdk = usePrevious(ctx.checkoutSdk);
+  const prevCheckoutSdk = usePrevious(sdk);
   React.useEffect(() => {
     // Ignore changes while checkout sdk is not initialized.
-    if (!ctx.checkoutSdk) {
+    if (!sdk) {
       return;
     }
 
-    const hasSdkLoaded = Boolean(!prevCheckoutSdk && ctx.checkoutSdk);
+    const hasSdkLoaded = Boolean(!prevCheckoutSdk && sdk);
 
     // Handle appearance changes
     const previousAppearance = prevOptions?.elementsOptions?.appearance;
@@ -189,7 +208,7 @@ export const CheckoutProvider: FunctionComponent<PropsWithChildren<
       previousAppearance
     );
     if (currentAppearance && (hasAppearanceChanged || hasSdkLoaded)) {
-      ctx.checkoutSdk.changeAppearance(currentAppearance);
+      sdk.changeAppearance(currentAppearance);
     }
 
     // Handle fonts changes
@@ -198,30 +217,24 @@ export const CheckoutProvider: FunctionComponent<PropsWithChildren<
     const hasFontsChanged = !isEqual(previousFonts, currentFonts);
 
     if (currentFonts && (hasFontsChanged || hasSdkLoaded)) {
-      ctx.checkoutSdk.loadFonts(currentFonts);
+      sdk.loadFonts(currentFonts);
     }
-  }, [options, prevOptions, ctx.checkoutSdk, prevCheckoutSdk]);
+  }, [options, prevOptions, sdk, prevCheckoutSdk]);
 
   // Attach react-stripe-js version to stripe.js instance
   React.useEffect(() => {
-    registerWithStripeJs(ctx.stripe);
-  }, [ctx.stripe]);
+    registerWithStripeJs(stripe);
+  }, [stripe]);
 
-  const checkoutContextValue = React.useMemo(
-    () => extractCheckoutContextValue(ctx.checkoutSdk, session),
-    [ctx.checkoutSdk, session]
-  );
-
-  if (!ctx.checkoutSdk) {
-    return null;
-  }
+  const contextValue = React.useMemo(() => getContextValue(stripe, state), [
+    stripe,
+    state,
+  ]);
 
   return (
-    <CheckoutSdkContext.Provider value={ctx}>
-      <CheckoutContext.Provider value={checkoutContextValue}>
-        {children}
-      </CheckoutContext.Provider>
-    </CheckoutSdkContext.Provider>
+    <CheckoutContext.Provider value={contextValue}>
+      {children}
+    </CheckoutContext.Provider>
   );
 }) as FunctionComponent<PropsWithChildren<CheckoutProviderProps>>;
 
@@ -233,40 +246,27 @@ CheckoutProvider.propTypes = {
   }).isRequired,
 };
 
-export const useCheckoutSdkContextWithUseCase = (
+export const useElementsOrCheckoutContextWithUseCase = (
   useCaseString: string
-): CheckoutSdkContextValue => {
-  const ctx = React.useContext(CheckoutSdkContext);
-  return parseCheckoutSdkContext(ctx, useCaseString);
+): CheckoutContextValue | ElementsContextValue => {
+  const checkout = React.useContext(CheckoutContext);
+  const elements = React.useContext(ElementsContext);
+
+  if (checkout) {
+    if (elements) {
+      throw new Error(
+        `You cannot wrap the part of your app that ${useCaseString} in both <CheckoutProvider> and <Elements> providers.`
+      );
+    } else {
+      return checkout;
+    }
+  } else {
+    return parseElementsContext(elements, useCaseString);
+  }
 };
 
-export const useElementsOrCheckoutSdkContextWithUseCase = (
-  useCaseString: string
-): CheckoutSdkContextValue | ElementsContextValue => {
-  const checkoutSdkContext = React.useContext(CheckoutSdkContext);
-  const elementsContext = React.useContext(ElementsContext);
-
-  if (checkoutSdkContext && elementsContext) {
-    throw new Error(
-      `You cannot wrap the part of your app that ${useCaseString} in both <CheckoutProvider> and <Elements> providers.`
-    );
-  }
-
-  if (checkoutSdkContext) {
-    return parseCheckoutSdkContext(checkoutSdkContext, useCaseString);
-  }
-
-  return parseElementsContext(elementsContext, useCaseString);
-};
-
-export const useCheckout = (): CheckoutContextValue => {
-  // ensure it's in CheckoutProvider
-  useCheckoutSdkContextWithUseCase('calls useCheckout()');
+export const useCheckout = (): CheckoutState => {
   const ctx = React.useContext(CheckoutContext);
-  if (!ctx) {
-    throw new Error(
-      'Could not find Checkout Context; You need to wrap the part of your app that calls useCheckout() in an <CheckoutProvider> provider.'
-    );
-  }
-  return ctx;
+  const {checkoutState} = validateCheckoutContext(ctx, 'calls useCheckout()');
+  return checkoutState;
 };

--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -14,7 +14,7 @@ import {
 } from '../types';
 
 const {Elements} = ElementsModule;
-const {CheckoutProvider} = CheckoutModule;
+const {CheckoutProvider, useCheckout} = CheckoutModule;
 
 describe('createElementComponent', () => {
   let mockStripe: any;
@@ -98,11 +98,12 @@ describe('createElementComponent', () => {
           stripe={null}
           options={{fetchClientSecret: async () => ''}}
         >
-          <CardElement />
+          <CardElement id="foo" />
         </CheckoutProvider>
       );
 
-      expect(container.firstChild).toBe(null);
+      const elementContainer = container.firstChild as Element;
+      expect(elementContainer.id).toBe('foo');
     });
   });
 
@@ -328,7 +329,7 @@ describe('createElementComponent', () => {
 
     it('attaches event listeners once the element is created', () => {
       jest
-        .spyOn(CheckoutModule, 'useElementsOrCheckoutSdkContextWithUseCase')
+        .spyOn(CheckoutModule, 'useElementsOrCheckoutContextWithUseCase')
         .mockReturnValueOnce({elements: null, stripe: null})
         .mockReturnValue({elements: mockElements, stripe: mockStripe});
 
@@ -973,6 +974,15 @@ describe('createElementComponent', () => {
           elementMounted = false;
         });
 
+        const TestComponent = () => {
+          const checkout = useCheckout();
+          if (checkout.type === 'success') {
+            return <PaymentElement />;
+          } else {
+            return null;
+          }
+        };
+
         act(() => {
           result = render(
             <StrictMode>
@@ -980,7 +990,7 @@ describe('createElementComponent', () => {
                 stripe={mockStripe}
                 options={{fetchClientSecret: async () => 'cs_123'}}
               >
-                <PaymentElement />
+                <TestComponent />
               </CheckoutProvider>
             </StrictMode>
           );

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -13,7 +13,7 @@ import {
   extractAllowedOptionsUpdates,
   UnknownOptions,
 } from '../utils/extractAllowedOptionsUpdates';
-import {useElementsOrCheckoutSdkContextWithUseCase} from './CheckoutProvider';
+import {useElementsOrCheckoutContextWithUseCase} from './CheckoutProvider';
 
 type UnknownCallback = (...args: unknown[]) => any;
 
@@ -62,11 +62,13 @@ const createElementComponent = (
     onShippingAddressChange,
     onShippingRateChange,
   }) => {
-    const ctx = useElementsOrCheckoutSdkContextWithUseCase(
+    const ctx = useElementsOrCheckoutContextWithUseCase(
       `mounts <${displayName}>`
     );
     const elements = 'elements' in ctx ? ctx.elements : null;
-    const checkoutSdk = 'checkoutSdk' in ctx ? ctx.checkoutSdk : null;
+    const checkoutState = 'checkoutState' in ctx ? ctx.checkoutState : null;
+    const checkoutSdk =
+      checkoutState?.type === 'success' ? checkoutState.checkout : null;
     const [element, setElement] = React.useState<stripeJs.StripeElement | null>(
       null
     );
@@ -205,7 +207,7 @@ const createElementComponent = (
 
   // Only render the Element wrapper in a server environment.
   const ServerElement: FunctionComponent<PrivateElementProps> = (props) => {
-    useElementsOrCheckoutSdkContextWithUseCase(`mounts <${displayName}>`);
+    useElementsOrCheckoutContextWithUseCase(`mounts <${displayName}>`);
     const {id, className} = props;
     return <div id={id} className={className} />;
   };

--- a/src/components/useStripe.tsx
+++ b/src/components/useStripe.tsx
@@ -1,12 +1,10 @@
 import * as stripeJs from '@stripe/stripe-js';
-import {useElementsOrCheckoutSdkContextWithUseCase} from './CheckoutProvider';
+import {useElementsOrCheckoutContextWithUseCase} from './CheckoutProvider';
 
 /**
  * @docs https://stripe.com/docs/stripe-js/react#usestripe-hook
  */
 export const useStripe = (): stripeJs.Stripe | null => {
-  const {stripe} = useElementsOrCheckoutSdkContextWithUseCase(
-    'calls useStripe()'
-  );
+  const {stripe} = useElementsOrCheckoutContextWithUseCase('calls useStripe()');
   return stripe;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export {useElements, Elements, ElementsConsumer} from './components/Elements';
 export {
   useCheckout,
   CheckoutProvider,
-  CheckoutContextValue,
+  CheckoutState,
 } from './components/CheckoutProvider';
 export {EmbeddedCheckout} from './components/EmbeddedCheckout';
 export {EmbeddedCheckoutProvider} from './components/EmbeddedCheckoutProvider';

--- a/test/makeDeferred.ts
+++ b/test/makeDeferred.ts
@@ -1,0 +1,21 @@
+const makeDeferred = <T extends any>() => {
+  let resolve!: (arg: T) => void;
+  let reject!: (arg: any) => void;
+  const promise: Promise<T> = new Promise((res: any, rej: any) => {
+    resolve = jest.fn(res);
+    reject = jest.fn(rej);
+  });
+  return {
+    resolve: async (arg: T) => {
+      resolve(arg);
+      await new Promise(process.nextTick);
+    },
+    reject: async (failure: any) => {
+      reject(failure);
+      await new Promise(process.nextTick);
+    },
+    promise,
+    getPromise: jest.fn(() => promise),
+  };
+};
+export default makeDeferred;


### PR DESCRIPTION
### Summary & motivation
r? @pololi-stripe 

Updates `CheckoutProvider` and `useCheckout` to return a disjoint union of loading/error/success always, rather than rendering null until everything loads.

### API review
[APIREVIEW-3693](https://jira.corp.stripe.com/browse/APIREVIEW-3693)

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
