### PR TITLE
Patch for global JSX namespace deprecation in React 19

### DIFF
--- a/src/components/EmbeddedCheckout.tsx
+++ b/src/components/EmbeddedCheckout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {FunctionComponent} from 'react';
 import {useEmbeddedCheckoutContext} from './EmbeddedCheckoutProvider';
 import {isServer} from '../utils/isServer';
 
@@ -60,6 +60,8 @@ const EmbeddedCheckoutServerElement = ({
   return <div id={id} className={className} />;
 };
 
-export const EmbeddedCheckout = isServer
+type EmbeddedCheckoutComponent = FunctionComponent<EmbeddedCheckoutProps>;
+
+export const EmbeddedCheckout: EmbeddedCheckoutComponent = isServer
   ? EmbeddedCheckoutServerElement
   : EmbeddedCheckoutClientElement;


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->
This is a simple patch for issue https://github.com/stripe/react-stripe-js/issues/569, without upgrading the whole repo to React 19 which is a bit more involved.

- Our public .d.ts now declares `EmbeddedCheckout` via `FunctionComponent`, aligning with other exports and avoiding the deprecated global JSX namespace under React 19.

### API review

<!-- Delete this section if this change involves no API changes. -->

Copy [this template] **or** link to an API review issue.

[this template]:
  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md

### Testing & documentation
 - I checked all the `d.ts` files this library emits, and found no more usages of the global `JSX`, which should fix errors in React 19 that the [issue](https://github.com/stripe/react-stripe-js/issues/569) outlined
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
