### PR TITLE
[breaking] split out custom checkout imports

### DIFF
--- a/checkout.d.ts
+++ b/checkout.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/checkout';

--- a/checkout.js
+++ b/checkout.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('./dist/checkout.js');

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "checkout.js",
+    "checkout.d.ts"
   ],
   "jest": {
     "preset": "ts-jest/presets/js-with-ts",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
       "types": "./dist/checkout.d.ts"
     }
   },
+  "typesVersions": {
+    "*": {
+      "checkout": ["dist/checkout.d.ts"]
+    }
+  },
   "scripts": {
     "test": "yarn run lint && yarn run lint:prettier && yarn run test:unit && yarn test:package-types && yarn run typecheck",
     "test:package-types": "attw --pack .",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,20 @@
   "browser:min": "dist/react-stripe.umd.min.js",
   "browser": "dist/react-stripe.umd.js",
   "types": "dist/react-stripe.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/react-stripe.js",
+      "import": "./dist/react-stripe.esm.mjs",
+      "default": "./dist/react-stripe.esm.mjs",
+      "types": "./dist/react-stripe.d.ts"
+    },
+    "./checkout": {
+      "require": "./dist/checkout.js",
+      "import": "./dist/checkout.esm.mjs",
+      "default": "./dist/checkout.esm.mjs",
+      "types": "./dist/checkout.d.ts"
+    }
+  },
   "scripts": {
     "test": "yarn run lint && yarn run lint:prettier && yarn run test:unit && yarn test:package-types && yarn run typecheck",
     "test:package-types": "attw --pack .",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,6 +30,16 @@ export default [
     ],
     plugins: PLUGINS,
   },
+  // Checkout subpath build (CJS and ESM)
+  {
+    input: 'src/checkout/index.ts',
+    external: ['react', 'prop-types'],
+    output: [
+      {file: 'dist/checkout.js', format: 'cjs'},
+      {file: 'dist/checkout.esm.mjs', format: 'es'},
+    ],
+    plugins: PLUGINS,
+  },
   // UMD build with inline PropTypes
   {
     input: 'src/index.ts',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,7 @@ export default [
     ],
     plugins: PLUGINS,
   },
-  // Checkout subpath build (CJS and ESM)
+  // Checkout subpath build
   {
     input: 'src/checkout/index.ts',
     external: ['react', 'prop-types'],

--- a/src/checkout/components/CheckoutProvider.test.tsx
+++ b/src/checkout/components/CheckoutProvider.test.tsx
@@ -3,10 +3,10 @@ import {render, act, waitFor} from '@testing-library/react';
 import {renderHook} from '@testing-library/react-hooks';
 
 import {CheckoutProvider, useCheckout} from './CheckoutProvider';
-import {Elements} from './Elements';
-import {useStripe} from './useStripe';
-import * as mocks from '../../test/mocks';
-import makeDeferred from '../../test/makeDeferred';
+import {Elements} from '../../components/Elements';
+import {useStripe} from '../../components/useStripe';
+import * as mocks from '../../../test/mocks';
+import makeDeferred from '../../../test/makeDeferred';
 
 describe('CheckoutProvider', () => {
   let mockStripe: any;

--- a/src/checkout/components/CheckoutProvider.tsx
+++ b/src/checkout/components/CheckoutProvider.tsx
@@ -4,15 +4,15 @@ import * as stripeJs from '@stripe/stripe-js';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {parseStripeProp} from '../utils/parseStripeProp';
-import {usePrevious} from '../utils/usePrevious';
-import {isEqual} from '../utils/isEqual';
+import {parseStripeProp} from '../../utils/parseStripeProp';
+import {usePrevious} from '../../utils/usePrevious';
+import {isEqual} from '../../utils/isEqual';
 import {
   ElementsContext,
   ElementsContextValue,
   parseElementsContext,
-} from './Elements';
-import {registerWithStripeJs} from '../utils/registerWithStripeJs';
+} from '../../components/Elements';
+import {registerWithStripeJs} from '../../utils/registerWithStripeJs';
 
 export type CheckoutValue = StripeCheckoutActions &
   stripeJs.StripeCheckoutSession;

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -11,11 +11,10 @@ import {
   CurrencySelectorElementComponent,
   BillingAddressElementComponent,
   ShippingAddressElementComponent,
-} from './types';
-import {
   PaymentElementComponent,
   ExpressCheckoutElementComponent,
-} from '../types';
+  TaxIdElementComponent,
+} from './types';
 
 /**
  * Requires beta access:
@@ -33,6 +32,11 @@ export const PaymentElement: PaymentElementComponent = createElementComponent(
 
 export const ExpressCheckoutElement: ExpressCheckoutElementComponent = createElementComponent(
   'expressCheckout',
+  isServer
+);
+
+export const TaxIdElement: TaxIdElementComponent = createElementComponent(
+  'taxId',
   isServer
 );
 

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -3,14 +3,19 @@ export {
   CheckoutProvider,
   CheckoutState,
 } from './components/CheckoutProvider';
-export type {
-  CurrencySelectorElementProps,
-  CurrencySelectorElementComponent,
-} from './types';
+export * from './types';
+import React from 'react';
 import createElementComponent from '../components/createElementComponent';
 import {isServer} from '../utils/isServer';
-import type {CurrencySelectorElementComponent} from './types';
-import type {PaymentElementComponent, ExpressCheckoutElementComponent} from '../types';
+import {
+  CurrencySelectorElementComponent,
+  BillingAddressElementComponent,
+  ShippingAddressElementComponent,
+} from './types';
+import {
+  PaymentElementComponent,
+  ExpressCheckoutElementComponent,
+} from '../types';
 
 /**
  * Requires beta access:
@@ -21,7 +26,6 @@ export const CurrencySelectorElement: CurrencySelectorElementComponent = createE
   isServer
 );
 
-// PaymentElement is available for both regular Elements and Checkout SDK.
 export const PaymentElement: PaymentElementComponent = createElementComponent(
   'payment',
   isServer
@@ -31,3 +35,21 @@ export const ExpressCheckoutElement: ExpressCheckoutElementComponent = createEle
   'expressCheckout',
   isServer
 );
+
+export const BillingAddressElement: BillingAddressElementComponent = ((
+  props
+) => {
+  const Component = createElementComponent('address', isServer) as any;
+  const {options, ...rest} = props as any;
+  const merged = {...options, mode: 'billing'};
+  return React.createElement(Component, {...rest, options: merged});
+}) as BillingAddressElementComponent;
+
+export const ShippingAddressElement: ShippingAddressElementComponent = ((
+  props
+) => {
+  const Component = createElementComponent('address', isServer) as any;
+  const {options, ...rest} = props as any;
+  const merged = {...options, mode: 'shipping'};
+  return React.createElement(Component, {...rest, options: merged});
+}) as ShippingAddressElementComponent;

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -10,6 +10,7 @@ export type {
 import createElementComponent from '../components/createElementComponent';
 import {isServer} from '../utils/isServer';
 import type {CurrencySelectorElementComponent} from './types';
+import type {PaymentElementComponent, ExpressCheckoutElementComponent} from '../types';
 
 /**
  * Requires beta access:
@@ -17,5 +18,16 @@ import type {CurrencySelectorElementComponent} from './types';
  */
 export const CurrencySelectorElement: CurrencySelectorElementComponent = createElementComponent(
   'currencySelector',
+  isServer
+);
+
+// PaymentElement is available for both regular Elements and Checkout SDK.
+export const PaymentElement: PaymentElementComponent = createElementComponent(
+  'payment',
+  isServer
+);
+
+export const ExpressCheckoutElement: ExpressCheckoutElementComponent = createElementComponent(
+  'expressCheckout',
   isServer
 );

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -1,0 +1,21 @@
+export {
+  useCheckout,
+  CheckoutProvider,
+  CheckoutState,
+} from './components/CheckoutProvider';
+export type {
+  CurrencySelectorElementProps,
+  CurrencySelectorElementComponent,
+} from './types';
+import createElementComponent from '../components/createElementComponent';
+import {isServer} from '../utils/isServer';
+import type {CurrencySelectorElementComponent} from './types';
+
+/**
+ * Requires beta access:
+ * Contact [Stripe support](https://support.stripe.com/) for more information.
+ */
+export const CurrencySelectorElement: CurrencySelectorElementComponent = createElementComponent(
+  'currencySelector',
+  isServer
+);

--- a/src/checkout/types/index.ts
+++ b/src/checkout/types/index.ts
@@ -32,3 +32,27 @@ export interface CurrencySelectorElementProps extends ElementProps {
 export type CurrencySelectorElementComponent = FunctionComponent<
   CurrencySelectorElementProps
 >;
+
+export interface BillingAddressElementProps extends ElementProps {
+  options?: stripeJs.StripeCheckoutAddressElementOptions;
+  onReady?: (element: stripeJs.StripeAddressElement) => any;
+  onEscape?: () => any;
+  onLoadError?: (event: {elementType: 'address'; error: StripeError}) => any;
+  onLoaderStart?: (event: {elementType: 'address'}) => any;
+}
+
+export type BillingAddressElementComponent = FunctionComponent<
+  BillingAddressElementProps
+>;
+
+export interface ShippingAddressElementProps extends ElementProps {
+  options?: stripeJs.StripeCheckoutAddressElementOptions;
+  onReady?: (element: stripeJs.StripeAddressElement) => any;
+  onEscape?: () => any;
+  onLoadError?: (event: {elementType: 'address'; error: StripeError}) => any;
+  onLoaderStart?: (event: {elementType: 'address'}) => any;
+}
+
+export type ShippingAddressElementComponent = FunctionComponent<
+  ShippingAddressElementProps
+>;

--- a/src/checkout/types/index.ts
+++ b/src/checkout/types/index.ts
@@ -1,7 +1,11 @@
 import {FunctionComponent} from 'react';
 import * as stripeJs from '@stripe/stripe-js';
 import {StripeError} from '@stripe/stripe-js';
-import {ElementProps} from '../../types';
+import {
+  ElementProps,
+  PaymentElementProps as RootPaymentElementProps,
+  ExpressCheckoutElementProps as RootExpressCheckoutElementProps,
+} from '../../types';
 
 export interface CurrencySelectorElementProps extends ElementProps {
   /**
@@ -56,3 +60,33 @@ export interface ShippingAddressElementProps extends ElementProps {
 export type ShippingAddressElementComponent = FunctionComponent<
   ShippingAddressElementProps
 >;
+
+export type PaymentElementProps = Omit<RootPaymentElementProps, 'options'> & {
+  options?: stripeJs.StripeCheckoutPaymentElementOptions;
+};
+
+export type PaymentElementComponent = FunctionComponent<PaymentElementProps>;
+
+export type ExpressCheckoutElementProps = Omit<
+  RootExpressCheckoutElementProps,
+  | 'options'
+  | 'onClick'
+  | 'onCancel'
+  | 'onShippingAddressChange'
+  | 'onShippingRateChange'
+> & {options?: stripeJs.StripeCheckoutExpressCheckoutElementOptions};
+
+export type ExpressCheckoutElementComponent = FunctionComponent<
+  ExpressCheckoutElementProps
+>;
+
+export interface TaxIdElementProps extends ElementProps {
+  options: stripeJs.StripeTaxIdElementOptions;
+  onChange?: (event: stripeJs.StripeTaxIdElementChangeEvent) => any;
+  onReady?: (element: stripeJs.StripeTaxIdElement) => any;
+  onEscape?: () => any;
+  onLoadError?: (event: {elementType: 'taxId'; error: StripeError}) => any;
+  onLoaderStart?: (event: {elementType: 'taxId'}) => any;
+}
+
+export type TaxIdElementComponent = FunctionComponent<TaxIdElementProps>;

--- a/src/checkout/types/index.ts
+++ b/src/checkout/types/index.ts
@@ -1,0 +1,34 @@
+import {FunctionComponent} from 'react';
+import * as stripeJs from '@stripe/stripe-js';
+import {StripeError} from '@stripe/stripe-js';
+import {ElementProps} from '../../types';
+
+export interface CurrencySelectorElementProps extends ElementProps {
+  /**
+   * Triggered when the Element is fully rendered and can accept imperative `element.focus()` calls.
+   * Called with a reference to the underlying [Element instance](https://stripe.com/docs/js/element).
+   */
+  onReady?: (element: stripeJs.StripeCurrencySelectorElement) => any;
+
+  /**
+   * Triggered when the escape key is pressed within the Element.
+   */
+  onEscape?: () => any;
+
+  /**
+   * Triggered when the Element fails to load.
+   */
+  onLoadError?: (event: {
+    elementType: 'currencySelector';
+    error: StripeError;
+  }) => any;
+
+  /**
+   * Triggered when the [loader](https://stripe.com/docs/js/elements_object/create#stripe_elements-options-loader) UI is mounted to the DOM and ready to be displayed.
+   */
+  onLoaderStart?: (event: {elementType: 'currencySelector'}) => any;
+}
+
+export type CurrencySelectorElementComponent = FunctionComponent<
+  CurrencySelectorElementProps
+>;

--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -2,7 +2,7 @@ import React, {StrictMode} from 'react';
 import {render, act, waitFor} from '@testing-library/react';
 
 import * as ElementsModule from './Elements';
-import * as CheckoutModule from './CheckoutProvider';
+import * as CheckoutModule from '../checkout/components/CheckoutProvider';
 import createElementComponent from './createElementComponent';
 import * as mocks from '../../test/mocks';
 import {

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -85,7 +85,9 @@ const createElementComponent = (
     useAttachEvent(element, 'blur', onBlur);
     useAttachEvent(element, 'focus', onFocus);
     useAttachEvent(element, 'escape', onEscape);
-    useAttachEvent(element, 'click', onClick);
+    // Hide click event for ExpressCheckoutElement in Checkout SDK
+    const shouldAttachClick = !(checkoutSdk && type === 'expressCheckout');
+    useAttachEvent(element, 'click', shouldAttachClick ? onClick : undefined);
     useAttachEvent(element, 'loaderror', onLoadError);
     useAttachEvent(element, 'loaderstart', onLoaderStart);
     useAttachEvent(element, 'networkschange', onNetworksChange);
@@ -130,6 +132,7 @@ const createElementComponent = (
         if (checkoutSdk) {
           switch (type) {
             case 'payment':
+              // Do we need to check for ApplePay here and for ECE below?
               newElement = checkoutSdk.createPaymentElement(options);
               break;
             case 'address':

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -13,7 +13,7 @@ import {
   extractAllowedOptionsUpdates,
   UnknownOptions,
 } from '../utils/extractAllowedOptionsUpdates';
-import {useElementsOrCheckoutContextWithUseCase} from './CheckoutProvider';
+import {useElementsOrCheckoutContextWithUseCase} from '../checkout/components/CheckoutProvider';
 
 type UnknownCallback = (...args: unknown[]) => any;
 

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -85,9 +85,7 @@ const createElementComponent = (
     useAttachEvent(element, 'blur', onBlur);
     useAttachEvent(element, 'focus', onFocus);
     useAttachEvent(element, 'escape', onEscape);
-    // Hide click event for ExpressCheckoutElement in Checkout SDK
-    const shouldAttachClick = !(checkoutSdk && type === 'expressCheckout');
-    useAttachEvent(element, 'click', shouldAttachClick ? onClick : undefined);
+    useAttachEvent(element, 'click', onClick);
     useAttachEvent(element, 'loaderror', onLoadError);
     useAttachEvent(element, 'loaderstart', onLoaderStart);
     useAttachEvent(element, 'networkschange', onNetworksChange);
@@ -132,7 +130,6 @@ const createElementComponent = (
         if (checkoutSdk) {
           switch (type) {
             case 'payment':
-              // Do we need to check for ApplePay here and for ECE below?
               newElement = checkoutSdk.createPaymentElement(options);
               break;
             case 'address':

--- a/src/components/useStripe.tsx
+++ b/src/components/useStripe.tsx
@@ -1,5 +1,5 @@
 import * as stripeJs from '@stripe/stripe-js';
-import {useElementsOrCheckoutContextWithUseCase} from './CheckoutProvider';
+import {useElementsOrCheckoutContextWithUseCase} from '../checkout/components/CheckoutProvider';
 
 /**
  * @docs https://stripe.com/docs/stripe-js/react#usestripe-hook

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,6 @@ import {
   AffirmMessageElementComponent,
   AfterpayClearpayMessageElementComponent,
   PaymentMethodMessagingElementComponent,
-  CurrencySelectorElementComponent,
   TaxIdElementComponent,
 } from './types';
 import {isServer} from './utils/isServer';
@@ -28,11 +27,6 @@ export * from './types';
 
 export {useElements, Elements, ElementsConsumer} from './components/Elements';
 
-export {
-  useCheckout,
-  CheckoutProvider,
-  CheckoutState,
-} from './components/CheckoutProvider';
 export {EmbeddedCheckout} from './components/EmbeddedCheckout';
 export {EmbeddedCheckoutProvider} from './components/EmbeddedCheckoutProvider';
 export {useStripe} from './components/useStripe';
@@ -133,14 +127,6 @@ export const ExpressCheckoutElement: ExpressCheckoutElementComponent = createEle
   isServer
 );
 
-/**
- * Requires beta access:
- * Contact [Stripe support](https://support.stripe.com/) for more information.
- */
-export const CurrencySelectorElement: CurrencySelectorElementComponent = createElementComponent(
-  'currencySelector',
-  isServer
-);
 
 /**
  * @docs https://stripe.com/docs/stripe-js/react#element-components

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,6 @@ export const ExpressCheckoutElement: ExpressCheckoutElementComponent = createEle
   isServer
 );
 
-
 /**
  * @docs https://stripe.com/docs/stripe-js/react#element-components
  */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -501,36 +501,6 @@ export type PaymentRequestButtonElementComponent = FunctionComponent<
   PaymentRequestButtonElementProps
 >;
 
-export interface CurrencySelectorElementProps extends ElementProps {
-  /**
-   * Triggered when the Element is fully rendered and can accept imperative `element.focus()` calls.
-   * Called with a reference to the underlying [Element instance](https://stripe.com/docs/js/element).
-   */
-  onReady?: (element: stripeJs.StripeCurrencySelectorElement) => any;
-
-  /**
-   * Triggered when the escape key is pressed within the Element.
-   */
-  onEscape?: () => any;
-
-  /**
-   * Triggered when the Element fails to load.
-   */
-  onLoadError?: (event: {
-    elementType: 'currencySelector';
-    error: StripeError;
-  }) => any;
-
-  /**
-   * Triggered when the [loader](https://stripe.com/docs/js/elements_object/create#stripe_elements-options-loader) UI is mounted to the DOM and ready to be displayed.
-   */
-  onLoaderStart?: (event: {elementType: 'currencySelector'}) => any;
-}
-
-export type CurrencySelectorElementComponent = FunctionComponent<
-  CurrencySelectorElementProps
->;
-
 export interface AddressElementProps extends ElementProps {
   /**
    * An object containing [Element configuration options](https://stripe.com/docs/js/elements_object/create_address_element#address_element_create-options).


### PR DESCRIPTION
### Summary & motivation

Splits EwCS specific imports into its own `/checkout` path.

### API Review
https://jira.corp.stripe.com/browse/APIREVIEW-3693

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
