### PR TITLE
Remove broken Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 React components for
 [Stripe.js and Elements](https://stripe.com/docs/stripe-js).
 
-[![build status](https://img.shields.io/travis/stripe/react-stripe-js/master.svg?style=flat-square)](https://travis-ci.org/stripe/react-stripe-js)
 [![npm version](https://img.shields.io/npm/v/@stripe/react-stripe-js.svg?style=flat-square)](https://www.npmjs.com/package/@stripe/react-stripe-js)
 
 ## Requirements


### PR DESCRIPTION
### Summary & motivation
This change removes the broken Travis badge from the readme

### Testing & documentation
Observed the [rendered readme](https://github.com/stripe/react-stripe-js/blob/c1fc55af33e5c20810cb38c9721833c369b92814/README.md) without the broken badge 