### PR TITLE
Fix Shipping/BillingAddressElement Render

### DIFF
--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -40,20 +40,16 @@ export const TaxIdElement: TaxIdElementComponent = createElementComponent(
   isServer
 );
 
-export const BillingAddressElement: BillingAddressElementComponent = ((
-  props
-) => {
-  const Component = createElementComponent('address', isServer) as any;
+const AddressElementBase = createElementComponent('address', isServer) as any;
+
+export const BillingAddressElement: BillingAddressElementComponent = (props => {
   const {options, ...rest} = props as any;
   const merged = {...options, mode: 'billing'};
-  return React.createElement(Component, {...rest, options: merged});
+  return React.createElement(AddressElementBase, {...rest, options: merged});
 }) as BillingAddressElementComponent;
 
-export const ShippingAddressElement: ShippingAddressElementComponent = ((
-  props
-) => {
-  const Component = createElementComponent('address', isServer) as any;
+export const ShippingAddressElement: ShippingAddressElementComponent = (props => {
   const {options, ...rest} = props as any;
   const merged = {...options, mode: 'shipping'};
-  return React.createElement(Component, {...rest, options: merged});
+  return React.createElement(AddressElementBase, {...rest, options: merged});
 }) as ShippingAddressElementComponent;


### PR DESCRIPTION
### Summary & motivation
Before:

https://github.com/user-attachments/assets/3e3354b3-cd58-4525-b47f-d50b38355630

After:

https://github.com/user-attachments/assets/b76c6d39-7a6d-4cd2-ba2a-bc5ddc203e50


<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->
Billing/ShippingAddressElement was calling `createElementComponent` inside their render, creating a new component type on each render. This was causing the element to un/remount, so move the address element base out of the render.

### Testing & documentation
Tested locally with `npm pack` and verified that inputting addresses into the Billing + Shipping AddressElements work as expected.
