### PR TITLE
export StripeCheckoutValue from checkout entrypoint #625

### DIFF
--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -2,6 +2,7 @@ export {
   useCheckout,
   CheckoutProvider,
   StripeUseCheckoutResult,
+  StripeCheckoutValue,
 } from './components/CheckoutProvider';
 export * from './types';
 import React from 'react';


### PR DESCRIPTION
### Summary & motivation

The quickstart Checkout example in TypeScript needs the  StripeCheckoutValue type, but it wasn’t exported from the public checkout entrypoint. Although  StripeCheckoutValue is defined in 
**react-stripe-js/src/checkout/components/CheckoutProvider.tsx**, it was not re-exported by
**react-stripe-js/src/checkout/index.ts,** so it didn’t appear in dist/checkout.d.ts. This PR re-exports 
StripeCheckoutValue to make it available via @stripe/react-stripe-js/checkout and unblock the TS quickstart flow.

### Change:

**react-stripe-js/src/checkout/index.ts**: add 
StripeCheckoutValue to the named exports from ./components/CheckoutProvider.


### API review

- Public API surface: type-only change.
- New public type export: StripeCheckoutValue is now exported from the checkout entrypoint.
- No runtime changes or behavioral changes.

### Testing & documentation

- Built and type-checked locally to ensure the declaration appears in **dist/checkout.d.ts**.

- Validated a consumer can import:

`import type { StripeCheckoutValue } from '@stripe/react-stripe-js/checkout';`
without referencing internal source paths.

- No docs changes required; this aligns the published types with the quickstart example expectations.
