### PR TITLE
[bug]: fix CheckoutProvider type exports

### DIFF
--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -2,12 +2,10 @@ export {
   useCheckout,
   CheckoutProvider,
 } from './components/CheckoutProvider';
-// prettier-ignore-start
 export type {
   StripeUseCheckoutResult,
   StripeCheckoutValue,
 } from './components/CheckoutProvider';
-// prettier-ignore-end
 export * from './types';
 import React from 'react';
 import createElementComponent from '../components/createElementComponent';


### PR DESCRIPTION
### Summary & motivation
`StripeUseCheckoutResult` and `StripeCheckoutValue` were not being exported as types so they were omitted from the bundle.

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation
[todo]: verify that after build that the types are exported in dist/checkout.d.ts
