### PR TITLE
Prepare for clover release

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "browser:min": "dist/react-stripe.umd.min.js",
   "browser": "dist/react-stripe.umd.js",
   "types": "dist/react-stripe.d.ts",
-  "releaseCandidate": true,
+  "releaseCandidate": false,
   "exports": {
     ".": {
       "require": "./dist/react-stripe.js",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "@storybook/react": "^6.5.0-beta.8",
-    "@stripe/stripe-js": "^8.0.0-rc.1",
+    "@stripe/stripe-js": "^8.0.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/react-hooks": "^8.0.0",
@@ -132,7 +132,7 @@
     "@types/react": "18.0.5"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": ">=8.0.0-rc.1 <9.0.0",
+    "@stripe/stripe-js": ">=8.0.0 <9.0.0",
     "react": ">=16.8.0 <20.0.0",
     "react-dom": ">=16.8.0 <20.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,10 +2350,10 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
-"@stripe/stripe-js@^8.0.0-rc.1":
-  version "8.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-8.0.0-rc.1.tgz#8c61f167b610bcfa92b65828b5fabbee133b70c8"
-  integrity sha512-lj6BFGL4gqx8iiIZ0znZTIQFguERi53lOKP3ZqIfc9E1ui7eJ4S6ZyWejcuuohuiQFPT3bpag3E9xZRS6qSujg==
+"@stripe/stripe-js@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-8.0.0.tgz#826c96834309a2b8f60394ad4496b71ae98fea86"
+  integrity sha512-dLvD55KT1cBmrqzgYRgY42qNcw6zW4HS5oRZs0xRvHw9gBWig5yDnWNop/E+/t2JK+OZO30zsnupVBN2MqW2mg==
 
 "@testing-library/dom@^8.5.0":
   version "8.13.0"


### PR DESCRIPTION
### Summary & motivation
Releasing react-stripe-js clover today

This PR will remain open until Stripe.js@8.0.0 is published so we can update peerDependency, devDependency, and the yarn lockfile.