### PR TITLE
Add Financial Account for Platforms disclosure React component

### DIFF
--- a/src/components/FinancialAccountDisclosure.test.tsx
+++ b/src/components/FinancialAccountDisclosure.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {render} from '@testing-library/react';
+import FinancialAccountDisclosure from './FinancialAccountDisclosure';
+import { StripeError, StripeErrorType } from '@stripe/stripe-js';
+import {mockStripe as baseMockStripe} from '../../test/mocks';
+
+const apiError: StripeErrorType = 'api_error';
+
+const mockStripeJs = (htmlElement: HTMLElement | undefined = document.createElement('div'), error: StripeError | undefined = undefined) => {
+  return {
+    ...baseMockStripe(),
+    createFinancialAccountDisclosure: jest.fn(() =>
+      Promise.resolve({
+        htmlElement,
+        error,
+      })
+    ),
+  };
+};
+
+describe('FinancialAccountDisclosure', () => {
+  let mockStripe: any;
+
+  beforeEach(() => {
+    mockStripe = mockStripeJs();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+
+  it('should render', () => {
+    render(<FinancialAccountDisclosure stripe={mockStripe} />);
+  });
+
+  it('should render when there is an error', () => {
+    const error: StripeError = {type: apiError, message: 'This is a test error'};
+    mockStripe = mockStripeJs(undefined, error);
+    render(<FinancialAccountDisclosure stripe={mockStripe} />);
+  });
+
+  it('should render with an onLoad callback', () => {
+    const onLoad = jest.fn();
+    render(<FinancialAccountDisclosure stripe={mockStripe} onLoad={onLoad} />);
+    expect(onLoad).toHaveBeenCalled();
+  });
+
+  it('should render with an onError callback', () => {
+    const onError = jest.fn();
+    render(<FinancialAccountDisclosure stripe={mockStripe} onError={onError} />);
+  });
+
+  it('should render with options', () => {
+    const options = {businessName: 'Test Business', learnMoreLink: 'https://test.com'};
+    render(<FinancialAccountDisclosure stripe={mockStripe} options={options} />);
+  });
+});

--- a/src/components/FinancialAccountDisclosure.test.tsx
+++ b/src/components/FinancialAccountDisclosure.test.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import {render} from '@testing-library/react';
 import FinancialAccountDisclosure from './FinancialAccountDisclosure';
-import { StripeError, StripeErrorType } from '@stripe/stripe-js';
+import {StripeError, StripeErrorType} from '@stripe/stripe-js';
 import {mockStripe as baseMockStripe} from '../../test/mocks';
 
 const apiError: StripeErrorType = 'api_error';
 
-const mockStripeJs = (htmlElement: HTMLElement | undefined = document.createElement('div'), error: StripeError | undefined = undefined) => {
+const mockStripeJs = (
+  htmlElement: HTMLElement | undefined = document.createElement('div'),
+  error: StripeError | undefined = undefined
+) => {
   return {
     ...baseMockStripe(),
     createFinancialAccountDisclosure: jest.fn(() =>
@@ -29,13 +32,15 @@ describe('FinancialAccountDisclosure', () => {
     jest.restoreAllMocks();
   });
 
-
   it('should render', () => {
     render(<FinancialAccountDisclosure stripe={mockStripe} />);
   });
 
   it('should render when there is an error', () => {
-    const error: StripeError = {type: apiError, message: 'This is a test error'};
+    const error: StripeError = {
+      type: apiError,
+      message: 'This is a test error',
+    };
     mockStripe = mockStripeJs(undefined, error);
     render(<FinancialAccountDisclosure stripe={mockStripe} />);
   });
@@ -48,11 +53,18 @@ describe('FinancialAccountDisclosure', () => {
 
   it('should render with an onError callback', () => {
     const onError = jest.fn();
-    render(<FinancialAccountDisclosure stripe={mockStripe} onError={onError} />);
+    render(
+      <FinancialAccountDisclosure stripe={mockStripe} onError={onError} />
+    );
   });
 
   it('should render with options', () => {
-    const options = {businessName: 'Test Business', learnMoreLink: 'https://test.com'};
-    render(<FinancialAccountDisclosure stripe={mockStripe} options={options} />);
+    const options = {
+      businessName: 'Test Business',
+      learnMoreLink: 'https://test.com',
+    };
+    render(
+      <FinancialAccountDisclosure stripe={mockStripe} options={options} />
+    );
   });
 });

--- a/src/components/FinancialAccountDisclosure.test.tsx
+++ b/src/components/FinancialAccountDisclosure.test.tsx
@@ -45,9 +45,10 @@ describe('FinancialAccountDisclosure', () => {
     render(<FinancialAccountDisclosure stripe={mockStripe} />);
   });
 
-  it('should render with an onLoad callback', () => {
+  it('should render with an onLoad callback', async () => {
     const onLoad = jest.fn();
     render(<FinancialAccountDisclosure stripe={mockStripe} onLoad={onLoad} />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(onLoad).toHaveBeenCalled();
   });
 

--- a/src/components/FinancialAccountDisclosure.tsx
+++ b/src/components/FinancialAccountDisclosure.tsx
@@ -1,0 +1,116 @@
+import * as stripeJs from '@stripe/stripe-js';
+import React from 'react';
+import {parseStripeProp} from '../utils/parseStripeProp';
+import {registerWithStripeJs} from '../utils/registerWithStripeJs';
+import {StripeError} from '@stripe/stripe-js';
+import {usePrevious} from '../utils/usePrevious';
+
+interface FinancialAccountDisclosureProps {
+  /**
+   * A [Stripe object](https://stripe.com/docs/js/initializing) or a `Promise` resolving to a `Stripe` object.
+   * The easiest way to initialize a `Stripe` object is with the the [Stripe.js wrapper module](https://github.com/stripe/stripe-js/blob/master/README.md#readme).
+   * Once this prop has been set, it can not be changed.
+   *
+   * You can also pass in `null` or a `Promise` resolving to `null` if you are performing an initial server-side render or when generating a static site.
+   */  
+  stripe: PromiseLike<stripeJs.Stripe | null> | stripeJs.Stripe | null;
+  
+  /**
+   * Callback function called when the disclosure content is loading.
+   */
+  onLoad?: () => void;
+
+  /**
+   * Callback function called when an error occurs during disclosure creation.
+   */
+  onError?: (error: StripeError) => void;
+
+  /**
+   * Optional Financial Account Disclosure configuration options.
+   * 
+   * businessName: The name of your business as you would like it to appear in the disclosure. If not provided, the business name will be inferred from the Stripe account.
+   * learnMoreLink: A supplemental link to for your users to learn more about Financial Accounts for platforms or any other relevant information included in the disclosure.
+   */
+  options?: {
+    businessName?: string;
+    learnMoreLink?: string;
+  };
+}
+
+const FinancialAccountDisclosure = ({
+  stripe: rawStripeProp,
+  onLoad,
+  onError,
+  options,
+}: FinancialAccountDisclosureProps) => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const parsed = React.useMemo(() => parseStripeProp(rawStripeProp), [
+    rawStripeProp,
+  ]);
+  const [stripeState, setStripeState] = React.useState<stripeJs.Stripe | null>(
+    parsed.tag === 'sync' ? parsed.stripe : null
+  );
+
+  React.useEffect(() => {
+    let isMounted = true;
+
+    if (parsed.tag === 'async') {
+      parsed.stripePromise.then((stripePromise: stripeJs.Stripe | null) => {
+        if (stripePromise && isMounted) {
+          setStripeState(stripePromise);
+        }
+      });
+    } else if (parsed.tag === 'sync') {
+      setStripeState(parsed.stripe);
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [parsed]);
+
+  // Warn on changes to stripe prop
+  const prevStripe = usePrevious(rawStripeProp);
+  React.useEffect(() => {
+    if (prevStripe !== null && prevStripe !== rawStripeProp) {
+      console.warn(
+        'Unsupported prop change on FinancialAccountDisclosure: You cannot change the `stripe` prop after setting it.'
+      );
+    }
+  }, [prevStripe, rawStripeProp]);
+
+  // Attach react-stripe-js version to stripe.js instance
+  React.useEffect(() => {
+    registerWithStripeJs(stripeState);
+  }, [stripeState]);
+
+  React.useEffect(() => {
+    const createDisclosure = async () => {
+      if (!stripeState || !containerRef.current) {
+        return;
+      }
+
+      const disclosurePromise = (stripeState as any).createFinancialAccountDisclosure(options);
+      
+      if (onLoad) {
+        onLoad();
+      }
+      
+      const {htmlElement: disclosureContent, error} = await disclosurePromise;
+
+      if (error && onError) {
+        onError(error);
+      } else if (disclosureContent) {
+        const container = containerRef.current;
+        container.innerHTML = '';
+        container.appendChild(disclosureContent);
+      }
+    };
+
+    createDisclosure();
+  }, [stripeState, options, onLoad, onError]);
+
+  return React.createElement('div', { ref: containerRef });
+};
+
+export default FinancialAccountDisclosure;

--- a/src/components/FinancialAccountDisclosure.tsx
+++ b/src/components/FinancialAccountDisclosure.tsx
@@ -12,9 +12,10 @@ interface FinancialAccountDisclosureProps {
    * Once this prop has been set, it can not be changed.
    *
    * You can also pass in `null` or a `Promise` resolving to `null` if you are performing an initial server-side render or when generating a static site.
-   */  
+   */
+
   stripe: PromiseLike<stripeJs.Stripe | null> | stripeJs.Stripe | null;
-  
+
   /**
    * Callback function called when the disclosure content is loading.
    */
@@ -27,7 +28,7 @@ interface FinancialAccountDisclosureProps {
 
   /**
    * Optional Financial Account Disclosure configuration options.
-   * 
+   *
    * businessName: The name of your business as you would like it to appear in the disclosure. If not provided, the business name will be inferred from the Stripe account.
    * learnMoreLink: A supplemental link to for your users to learn more about Financial Accounts for platforms or any other relevant information included in the disclosure.
    */
@@ -90,12 +91,14 @@ const FinancialAccountDisclosure = ({
         return;
       }
 
-      const disclosurePromise = (stripeState as any).createFinancialAccountDisclosure(options);
-      
+      const disclosurePromise = (stripeState as any).createFinancialAccountDisclosure(
+        options
+      );
+
       if (onLoad) {
         onLoad();
       }
-      
+
       const {htmlElement: disclosureContent, error} = await disclosurePromise;
 
       if (error && onError) {
@@ -110,7 +113,7 @@ const FinancialAccountDisclosure = ({
     createDisclosure();
   }, [stripeState, options, onLoad, onError]);
 
-  return React.createElement('div', { ref: containerRef });
+  return React.createElement('div', {ref: containerRef});
 };
 
 export default FinancialAccountDisclosure;

--- a/src/components/FinancialAccountDisclosure.tsx
+++ b/src/components/FinancialAccountDisclosure.tsx
@@ -44,6 +44,8 @@ const FinancialAccountDisclosure = ({
   onError,
   options,
 }: FinancialAccountDisclosureProps) => {
+  const businessName = options?.businessName;
+  const learnMoreLink = options?.learnMoreLink;
   const containerRef = React.useRef<HTMLDivElement>(null);
   const parsed = React.useMemo(() => parseStripeProp(rawStripeProp), [
     rawStripeProp,
@@ -91,15 +93,13 @@ const FinancialAccountDisclosure = ({
         return;
       }
 
-      const disclosurePromise = (stripeState as any).createFinancialAccountDisclosure(
-        options
-      );
-
-      if (onLoad) {
-        onLoad();
-      }
-
-      const {htmlElement: disclosureContent, error} = await disclosurePromise;
+      const {
+        htmlElement: disclosureContent,
+        error,
+      } = await (stripeState as any).createFinancialAccountDisclosure({
+        businessName,
+        learnMoreLink,
+      });
 
       if (error && onError) {
         onError(error);
@@ -107,11 +107,14 @@ const FinancialAccountDisclosure = ({
         const container = containerRef.current;
         container.innerHTML = '';
         container.appendChild(disclosureContent);
+        if (onLoad) {
+          onLoad();
+        }
       }
     };
 
     createDisclosure();
-  }, [stripeState, options, onLoad, onError]);
+  }, [stripeState, businessName, learnMoreLink, onLoad, onError]);
 
   return React.createElement('div', {ref: containerRef});
 };


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Adds a new React component, `FinancialAccountDisclosure`, that users can use to add the compulsory disclosure text detailing our Financial Account (FA) for platforms product (fka Treasury), the banking partners we work with, and information about FDIC insurance.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

I tested this change by creating a new local testing file in `examples/hooks` and running `yarn run storybook`

You can see the files I used to test [here](https://github.com/stripe/react-stripe-js/commit/80d8c4937bafe31eaba84779e9fc2eb507edbc7a).

I also wrote tests in `src/components/FinancialAccountDisclosure.test.tsx` that I ran with `yarn jest`