### PR TITLE
Add onChange to Shipping and Billing Address Element

### DIFF
--- a/src/checkout/types/index.ts
+++ b/src/checkout/types/index.ts
@@ -5,6 +5,7 @@ import {
   ElementProps,
   PaymentElementProps as RootPaymentElementProps,
   ExpressCheckoutElementProps as RootExpressCheckoutElementProps,
+  AddressElementProps as RootAddressElementProps,
 } from '../../types';
 
 export interface CurrencySelectorElementProps extends ElementProps {
@@ -37,27 +38,23 @@ export type CurrencySelectorElementComponent = FunctionComponent<
   CurrencySelectorElementProps
 >;
 
-export interface BillingAddressElementProps extends ElementProps {
+export type BillingAddressElementProps = Omit<
+  RootAddressElementProps,
+  'options'
+> & {
   options?: stripeJs.StripeCheckoutAddressElementOptions;
-  onChange?: (event: stripeJs.StripeAddressElementChangeEvent) => any;
-  onReady?: (element: stripeJs.StripeAddressElement) => any;
-  onEscape?: () => any;
-  onLoadError?: (event: {elementType: 'address'; error: StripeError}) => any;
-  onLoaderStart?: (event: {elementType: 'address'}) => any;
-}
+};
 
 export type BillingAddressElementComponent = FunctionComponent<
   BillingAddressElementProps
 >;
 
-export interface ShippingAddressElementProps extends ElementProps {
+export type ShippingAddressElementProps = Omit<
+  RootAddressElementProps,
+  'options'
+> & {
   options?: stripeJs.StripeCheckoutAddressElementOptions;
-  onChange?: (event: stripeJs.StripeAddressElementChangeEvent) => any;
-  onReady?: (element: stripeJs.StripeAddressElement) => any;
-  onEscape?: () => any;
-  onLoadError?: (event: {elementType: 'address'; error: StripeError}) => any;
-  onLoaderStart?: (event: {elementType: 'address'}) => any;
-}
+};
 
 export type ShippingAddressElementComponent = FunctionComponent<
   ShippingAddressElementProps


### PR DESCRIPTION
### Summary & motivation

We missed adding `onChange` as a valid prop for Billing Address and Shipping Address Elements. This adds this by re-using the existing AE props type we have for Elements. You can compare with [the type](https://github.com/stripe/react-stripe-js/blob/cbc9fabefc995914ec7778cb69d9cde681b00313/src/types/index.ts#L398) here that the only diff is an additional `onChange` prop.