### PR TITLE
Export disclosure components with typing

### DIFF
--- a/src/components/FinancialAccountDisclosure.test.tsx
+++ b/src/components/FinancialAccountDisclosure.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {render} from '@testing-library/react';
-import FinancialAccountDisclosure from './FinancialAccountDisclosure';
+import {FinancialAccountDisclosure} from './FinancialAccountDisclosure';
 import {StripeErrorType} from '@stripe/stripe-js';
 import {mockStripe as baseMockStripe} from '../../test/mocks';
 

--- a/src/components/FinancialAccountDisclosure.tsx
+++ b/src/components/FinancialAccountDisclosure.tsx
@@ -1,5 +1,5 @@
 import * as stripeJs from '@stripe/stripe-js';
-import React from 'react';
+import React, {FunctionComponent} from 'react';
 import {parseStripeProp} from '../utils/parseStripeProp';
 import {registerWithStripeJs} from '../utils/registerWithStripeJs';
 import {StripeError} from '@stripe/stripe-js';
@@ -37,12 +37,12 @@ interface FinancialAccountDisclosureProps {
   };
 }
 
-const FinancialAccountDisclosure = ({
+export const FinancialAccountDisclosure: FunctionComponent<FinancialAccountDisclosureProps> = ({
   stripe: rawStripeProp,
   onLoad,
   onError,
   options,
-}: FinancialAccountDisclosureProps) => {
+}) => {
   const businessName = options?.businessName;
   const learnMoreLink = options?.learnMoreLink;
 
@@ -118,5 +118,3 @@ const FinancialAccountDisclosure = ({
 
   return React.createElement('div', {ref: containerRef});
 };
-
-export default FinancialAccountDisclosure;

--- a/src/components/IssuingDisclosure.test.tsx
+++ b/src/components/IssuingDisclosure.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {render} from '@testing-library/react';
-import IssuingDisclosure from './IssuingDisclosure';
+import {IssuingDisclosure} from './IssuingDisclosure';
 import {StripeErrorType} from '@stripe/stripe-js';
 import {mockStripe as baseMockStripe} from '../../test/mocks';
 

--- a/src/components/IssuingDisclosure.tsx
+++ b/src/components/IssuingDisclosure.tsx
@@ -1,5 +1,5 @@
 import * as stripeJs from '@stripe/stripe-js';
-import React from 'react';
+import React, {FunctionComponent} from 'react';
 import {parseStripeProp} from '../utils/parseStripeProp';
 import {registerWithStripeJs} from '../utils/registerWithStripeJs';
 import {StripeError} from '@stripe/stripe-js';
@@ -39,12 +39,12 @@ interface IssuingDisclosureProps {
   };
 }
 
-const IssuingDisclosure = ({
+export const IssuingDisclosure: FunctionComponent<IssuingDisclosureProps> = ({
   stripe: rawStripeProp,
   onLoad,
   onError,
   options,
-}: IssuingDisclosureProps) => {
+}) => {
   const issuingProgramID = options?.issuingProgramID;
   const publicCardProgramName = options?.publicCardProgramName;
   const learnMoreLink = options?.learnMoreLink;
@@ -129,5 +129,3 @@ const IssuingDisclosure = ({
 
   return React.createElement('div', {ref: containerRef});
 };
-
-export default IssuingDisclosure;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ export {useElements, Elements, ElementsConsumer} from './components/Elements';
 
 export {EmbeddedCheckout} from './components/EmbeddedCheckout';
 export {EmbeddedCheckoutProvider} from './components/EmbeddedCheckoutProvider';
+export {FinancialAccountDisclosure} from './components/FinancialAccountDisclosure';
+export {IssuingDisclosure} from './components/IssuingDisclosure';
 export {useStripe} from './components/useStripe';
 
 /**


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Adds and exports `FinancialAccountDisclosure` and `IssuingDisclosure` components with proper typing.

### Testing & documentation

I tested this change by creating a new local testing file in `examples/hooks` and running `yarn run storybook`

I also made sure the tests in  `src/components/FinancialAccountDisclosure.test.tsx` and `src/components/IssuingDisclosure.test.tsx` still pass by running `yarn jest`
