### PR TITLE
add contactDetails element

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "@storybook/react": "^6.5.0-beta.8",
-    "@stripe/stripe-js": "^9.0.0",
+    "@stripe/stripe-js": "^9.2.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/react-hooks": "^8.0.0",
@@ -132,7 +132,7 @@
     "@types/react": "18.0.5"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": ">=9.0.0 <10.0.0",
+    "@stripe/stripe-js": ">=9.2.0 <10.0.0",
     "react": ">=16.8.0 <20.0.0",
     "react-dom": ">=16.8.0 <20.0.0"
   }

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -17,6 +17,7 @@ import {
   CheckoutFormComponent,
   ExpressCheckoutElementComponent,
   TaxIdElementComponent,
+  ContactDetailsElementComponent,
 } from './types';
 
 export const CurrencySelectorElement: CurrencySelectorElementComponent = createElementComponent(
@@ -42,6 +43,11 @@ export const ExpressCheckoutElement: ExpressCheckoutElementComponent = createEle
 
 export const TaxIdElement: TaxIdElementComponent = createElementComponent(
   'taxId',
+  isServer
+);
+
+export const ContactDetailsElement: ContactDetailsElementComponent = createElementComponent(
+  'contactDetails',
   isServer
 );
 

--- a/src/checkout/types/index.ts
+++ b/src/checkout/types/index.ts
@@ -94,3 +94,19 @@ export interface TaxIdElementProps extends ElementProps {
 }
 
 export type TaxIdElementComponent = FunctionComponent<TaxIdElementProps>;
+
+export interface ContactDetailsElementProps extends ElementProps {
+  options?: stripeJs.StripeContactDetailsElementOptions;
+  onChange?: (event: stripeJs.StripeContactDetailsElementChangeEvent) => any;
+  onReady?: (element: stripeJs.StripeContactDetailsElement) => any;
+  onEscape?: () => any;
+  onLoadError?: (event: {
+    elementType: 'contactDetails';
+    error: StripeError;
+  }) => any;
+  onLoaderStart?: (event: {elementType: 'contactDetails'}) => any;
+}
+
+export type ContactDetailsElementComponent = FunctionComponent<
+  ContactDetailsElementProps
+>;

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -173,6 +173,9 @@ const createElementComponent = (
             case 'taxId':
               newElement = elementsSdk.createTaxIdElement(options);
               break;
+            case 'contactDetails':
+              newElement = elementsSdk.createContactDetailsElement();
+              break;
             default:
               throw new Error(
                 `<${displayName}> is not supported inside a checkout provider. Use an <Elements> provider instead.`

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   CardNumberElementComponent,
   CardExpiryElementComponent,
   CardCvcElementComponent,
+  ContactDetailsElementComponent,
   ExpressCheckoutElementComponent,
   IbanElementComponent,
   IssuingCardCopyButtonElementComponent,
@@ -109,6 +110,14 @@ export const PaymentRequestButtonElement: PaymentRequestButtonElementComponent =
  */
 export const LinkAuthenticationElement: LinkAuthenticationElementComponent = createElementComponent(
   'linkAuthentication',
+  isServer
+);
+
+/**
+ * @docs https://stripe.com/docs/stripe-js/react#element-components
+ */
+export const ContactDetailsElement: ContactDetailsElementComponent = createElementComponent(
+  'contactDetails',
   isServer
 );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -251,6 +251,47 @@ export type LinkAuthenticationElementComponent = FunctionComponent<
   LinkAuthenticationElementProps
 >;
 
+export interface ContactDetailsElementProps extends ElementProps {
+  /**
+   * An object containing Element configuration options.
+   */
+  options?: stripeJs.StripeContactDetailsElementOptions;
+
+  /**
+   * Triggered when data exposed by this Element is changed (e.g., when there is an error).
+   * For more information, refer to the [Stripe.js reference](https://stripe.com/docs/js/element/events/on_change?type=auBankAccountElement).
+   */
+  onChange?: (event: stripeJs.StripeContactDetailsElementChangeEvent) => any;
+
+  /**
+   * Triggered when the Element is fully rendered and can accept imperative `element.focus()` calls.
+   * Called with a reference to the underlying [Element instance](https://stripe.com/docs/js/element).
+   */
+  onReady?: (element: stripeJs.StripeContactDetailsElement) => any;
+
+  /**
+   * Triggered when the escape key is pressed within the Element.
+   */
+  onEscape?: () => any;
+
+  /**
+   * Triggered when the Element fails to load.
+   */
+  onLoadError?: (event: {
+    elementType: 'contactDetails';
+    error: StripeError;
+  }) => any;
+
+  /**
+   * Triggered when the [loader](https://stripe.com/docs/js/elements_object/create#stripe_elements-options-loader) UI is mounted to the DOM and ready to be displayed.
+   */
+  onLoaderStart?: (event: {elementType: 'contactDetails'}) => any;
+}
+
+export type ContactDetailsElementComponent = FunctionComponent<
+  ContactDetailsElementProps
+>;
+
 /**
  * Requires beta access:
  * Contact [Stripe support](https://support.stripe.com/) for more information.

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -107,6 +107,13 @@ export const mockCheckoutSdk = () => {
     getTaxIdElement: jest.fn(() => {
       return elements.taxId || null;
     }),
+    createContactDetailsElement: jest.fn(() => {
+      elements.contactDetails = mockElement();
+      return elements.contactDetails;
+    }),
+    getContactDetailsElement: jest.fn(() => {
+      return elements.contactDetails || null;
+    }),
 
     on: jest.fn((event, callback) => {
       if (event === 'change') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,10 +2395,10 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
-"@stripe/stripe-js@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-9.0.0.tgz#10d9a22e437fe7704e015909ece43acb6abb1fc0"
-  integrity sha512-UtUK7LFglQSNVIOwcRBaxfzq4wkfU8CT2f2uQVEeu65jTP6wicxFshYdYCke9Tfd0PCxhOe/b8rwJjr5EiDCfQ==
+"@stripe/stripe-js@^9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-9.2.0.tgz#2579b4c13ff2f1316c08e80b1bbec6dbb4d9b661"
+  integrity sha512-YSzLC0t6VS9MDdPTynSMqU8IxrItFUjkDORALFT6sSMR/XZ5Vgm3RDp/Gk7z727MC4A9s4MFVel0gF0c7+kdrg==
 
 "@testing-library/dom@^8.5.0":
   version "8.13.0"


### PR DESCRIPTION
### Summary & motivation

Adds  the `contactDetails` element, which is a clone of `linkAuthentication` element that will possibly collect values other than an email.
The element is also going to be available with Checkout elements.

### Testing & documentation

Tested locally. Documentation will be updated soon.
