### PR TITLE
Type updates to fix reduced actions in form sdk

### DIFF
--- a/examples/hooks/11-Custom-Checkout.js
+++ b/examples/hooks/11-Custom-Checkout.js
@@ -3,7 +3,7 @@ import {loadStripe} from '@stripe/stripe-js';
 import {
   PaymentElement,
   CheckoutElementsProvider,
-  useCheckout,
+  useCheckoutElements,
   BillingAddressElement,
 } from '../../src/checkout';
 
@@ -44,7 +44,7 @@ const CustomerDetails = ({phoneNumber, setPhoneNumber, email, setEmail}) => {
 };
 
 const CheckoutForm = () => {
-  const checkoutState = useCheckout();
+  const checkoutState = useCheckoutElements();
   const [status, setStatus] = React.useState();
   const [loading, setLoading] = React.useState(false);
   const [phoneNumber, setPhoneNumber] = React.useState('');

--- a/examples/hooks/13-Checkout-Form.js
+++ b/examples/hooks/13-Checkout-Form.js
@@ -3,13 +3,13 @@ import {loadStripe} from '@stripe/stripe-js';
 import {
   CheckoutForm,
   CheckoutFormProvider,
-  useCheckout,
+  useCheckoutForm,
 } from '../../src/checkout';
 
 import '../styles/common.css';
 
 const CheckoutFormExample = ({layout}) => {
-  const checkoutState = useCheckout();
+  const checkoutState = useCheckoutForm();
 
   if (checkoutState.type === 'error') {
     return <div>Error: {checkoutState.error.message}</div>;

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "@storybook/react": "^6.5.0-beta.8",
-    "@stripe/stripe-js": "^9.2.0",
+    "@stripe/stripe-js": "^9.3.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/react-hooks": "^8.0.0",
@@ -132,7 +132,7 @@
     "@types/react": "18.0.5"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": ">=9.2.0 <10.0.0",
+    "@stripe/stripe-js": ">=9.3.1 <10.0.0",
     "react": ">=16.8.0 <20.0.0",
     "react-dom": ">=16.8.0 <20.0.0"
   }

--- a/src/checkout/components/CheckoutContext.tsx
+++ b/src/checkout/components/CheckoutContext.tsx
@@ -159,7 +159,8 @@ const mapStateToCheckoutResult = <
 };
 
 /**
- * @deprecated Prefer the provider-specific hooks:
+ * @deprecated Since v6.3.0. Will be removed in v7.0.0. Prefer the
+ * provider-specific hooks:
  * - Inside `<CheckoutElementsProvider>`, use `useCheckoutElements()`.
  * - Inside `<CheckoutFormProvider>`, use `useCheckoutForm()`.
  *

--- a/src/checkout/components/CheckoutContext.tsx
+++ b/src/checkout/components/CheckoutContext.tsx
@@ -12,8 +12,13 @@ type CheckoutSdk =
   | stripeJs.StripeCheckoutElementsSdk
   | stripeJs.StripeCheckoutFormSdk;
 
-type LoadActionsSuccess = Extract<
+type ElementsLoadActionsSuccess = Extract<
   stripeJs.StripeCheckoutLoadActionsResult,
+  {type: 'success'}
+>['actions'];
+
+type FormLoadActionsSuccess = Extract<
+  stripeJs.StripeCheckoutFormLoadActionsResult,
   {type: 'success'}
 >['actions'];
 
@@ -24,8 +29,16 @@ export type CheckoutState =
     }
   | {
       type: 'success';
-      sdk: CheckoutSdk;
-      checkoutActions: LoadActionsSuccess;
+      sdkKind: 'elements';
+      sdk: stripeJs.StripeCheckoutElementsSdk;
+      checkoutActions: ElementsLoadActionsSuccess;
+      session: stripeJs.StripeCheckoutSession;
+    }
+  | {
+      type: 'success';
+      sdkKind: 'form';
+      sdk: stripeJs.StripeCheckoutFormSdk;
+      checkoutActions: FormLoadActionsSuccess;
       session: stripeJs.StripeCheckoutSession;
     }
   | {type: 'error'; error: {message: string}};
@@ -71,59 +84,124 @@ export const useElementsOrCheckoutContextWithUseCase = (
   }
 };
 
-type DistributiveOmit<T, K extends keyof any> = T extends any
-  ? Omit<T, K>
-  : never;
-
-type StripeCheckoutActions = DistributiveOmit<
-  CheckoutSdk,
+type StripeCheckoutElementsActions = Omit<
+  stripeJs.StripeCheckoutElementsSdk,
   'on' | 'loadActions'
 > &
-  Omit<LoadActionsSuccess, 'getSession'>;
+  Omit<ElementsLoadActionsSuccess, 'getSession'>;
 
-export type StripeCheckoutValue = StripeCheckoutActions &
+type StripeCheckoutFormActions = Omit<
+  stripeJs.StripeCheckoutFormSdk,
+  'on' | 'loadActions'
+> &
+  Omit<FormLoadActionsSuccess, 'getSession'>;
+
+export type StripeCheckoutElementsValue = StripeCheckoutElementsActions &
   stripeJs.StripeCheckoutSession;
 
-export type StripeUseCheckoutResult =
+export type StripeCheckoutFormValue = StripeCheckoutFormActions &
+  stripeJs.StripeCheckoutSession;
+
+// Back-compat alias: pre-existing consumers of StripeCheckoutValue see the
+// Elements shape (unchanged behavior). Form consumers should prefer the
+// narrower StripeCheckoutFormValue returned by useCheckoutForm().
+export type StripeCheckoutValue = StripeCheckoutElementsValue;
+
+export type StripeUseCheckoutElementsResult =
   | {type: 'loading'}
   | {
       type: 'success';
-      checkout: StripeCheckoutValue;
+      checkout: StripeCheckoutElementsValue;
     }
   | {type: 'error'; error: {message: string}};
 
-const mapStateToUseCheckoutResult = (
+export type StripeUseCheckoutFormResult =
+  | {type: 'loading'}
+  | {
+      type: 'success';
+      checkout: StripeCheckoutFormValue;
+    }
+  | {type: 'error'; error: {message: string}};
+
+// Back-compat alias: useCheckout() keeps returning the Elements-shaped result
+// regardless of which provider wraps the tree. See useCheckout() JSDoc below.
+export type StripeUseCheckoutResult = StripeUseCheckoutElementsResult;
+
+// One runtime shape, two possible static types depending on the calling hook.
+// The spread destructure runs uniformly against either SDK kind because both
+// StripeCheckoutElementsSdk and StripeCheckoutFormSdk expose `on` and
+// `loadActions`; the final cast selects the surface that the caller expects.
+const mapStateToCheckoutResult = <
+  T extends StripeCheckoutElementsValue | StripeCheckoutFormValue
+>(
   checkoutState: CheckoutState
-): StripeUseCheckoutResult => {
+):
+  | {type: 'loading'}
+  | {type: 'success'; checkout: T}
+  | {type: 'error'; error: {message: string}} => {
   if (checkoutState.type === 'success') {
     const {sdk, session, checkoutActions} = checkoutState;
-    const {on: _on, loadActions: _loadActions, ...elementsMethods} = sdk;
+    const {on: _on, loadActions: _loadActions, ...sdkMethods} = sdk;
     const {getSession: _getSession, ...otherCheckoutActions} = checkoutActions;
-    const actions = {
-      ...elementsMethods,
-      ...otherCheckoutActions,
-    };
     return {
       type: 'success',
-      checkout: {
+      checkout: ({
         ...session,
-        ...actions,
-      },
+        ...sdkMethods,
+        ...otherCheckoutActions,
+      } as unknown) as T,
     };
   } else if (checkoutState.type === 'loading') {
-    return {
-      type: 'loading',
-    };
+    return {type: 'loading'};
   } else {
-    return {
-      type: 'error',
-      error: checkoutState.error,
-    };
+    return {type: 'error', error: checkoutState.error};
   }
 };
 
+/**
+ * @deprecated Prefer the provider-specific hooks:
+ * - Inside `<CheckoutElementsProvider>`, use `useCheckoutElements()`.
+ * - Inside `<CheckoutFormProvider>`, use `useCheckoutForm()`.
+ *
+ * The provider-specific hooks return the exact action surface exposed by
+ * their SDK.
+ *
+ * `useCheckout()` will keep working under both providers and returns the
+ * Elements-shaped result for backward compatibility.
+ */
 export const useCheckout = (): StripeUseCheckoutResult => {
   const ctx = React.useContext(CheckoutContext);
   const {checkoutState} = validateCheckoutContext(ctx, 'calls useCheckout()');
-  return mapStateToUseCheckoutResult(checkoutState);
+  return mapStateToCheckoutResult<StripeCheckoutElementsValue>(checkoutState);
+};
+
+export const useCheckoutElements = (): StripeUseCheckoutElementsResult => {
+  const ctx = React.useContext(CheckoutContext);
+  const {checkoutState} = validateCheckoutContext(
+    ctx,
+    'calls useCheckoutElements()'
+  );
+  if (
+    checkoutState.type === 'success' &&
+    checkoutState.sdkKind !== 'elements'
+  ) {
+    throw new Error(
+      'useCheckoutElements() must be used inside <CheckoutElementsProvider>. Inside <CheckoutFormProvider>, use useCheckoutForm() instead.'
+    );
+  }
+  return mapStateToCheckoutResult<StripeCheckoutElementsValue>(checkoutState);
+};
+
+export const useCheckoutForm = (): StripeUseCheckoutFormResult => {
+  const ctx = React.useContext(CheckoutContext);
+  const {checkoutState} = validateCheckoutContext(
+    ctx,
+    'calls useCheckoutForm()'
+  );
+  if (checkoutState.type === 'success' && checkoutState.sdkKind !== 'form') {
+    throw new Error(
+      'useCheckoutForm() must be used inside <CheckoutFormProvider>. Inside <CheckoutElementsProvider>, use useCheckoutElements() instead.'
+    );
+  }
+  return mapStateToCheckoutResult<StripeCheckoutFormValue>(checkoutState);
 };

--- a/src/checkout/components/CheckoutElementsProvider.test.tsx
+++ b/src/checkout/components/CheckoutElementsProvider.test.tsx
@@ -3,7 +3,11 @@ import {render, act, waitFor} from '@testing-library/react';
 import {renderHook} from '@testing-library/react-hooks';
 
 import {CheckoutElementsProvider} from './CheckoutElementsProvider';
-import {useCheckout} from './CheckoutContext';
+import {
+  useCheckout,
+  useCheckoutElements,
+  useCheckoutForm,
+} from './CheckoutContext';
 import {Elements} from '../../components/Elements';
 import {useStripe} from '../../components/useStripe';
 import * as mocks from '../../../test/mocks';
@@ -183,6 +187,103 @@ describe('CheckoutElementsProvider', () => {
       await act(() => mockStripePromise);
 
       expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    // Regression guard for the public Elements SDK surface documented at
+    // https://docs.stripe.com/sdks/stripejs-react. Any accidental narrowing
+    // of StripeCheckoutValue that drops these methods would break every
+    // <CheckoutElementsProvider> consumer calling them from useCheckout().
+    it('exposes every action method returned by loadActions on useCheckout().checkout', async () => {
+      const testMockCheckoutActions = mocks.mockCheckoutActions();
+      mockCheckoutSdk.loadActions.mockResolvedValue({
+        type: 'success',
+        actions: testMockCheckoutActions,
+      });
+
+      const {result, waitForNextUpdate} = renderHook(() => useCheckout(), {
+        wrapper,
+        initialProps: {stripe: mockStripe},
+      });
+
+      await waitForNextUpdate();
+
+      if (result.current.type !== 'success') {
+        throw new Error(
+          `expected success, got ${JSON.stringify(result.current)}`
+        );
+      }
+      const {checkout} = result.current;
+
+      // Every action key from the SDK (except getSession, whose fields are
+      // spread onto checkout as session data) must be a function. Derived
+      // from the mock so this stays honest if the shared mock is updated.
+      const {
+        getSession: _getSession,
+        ...expectedActionKeys
+      } = testMockCheckoutActions;
+      Object.keys(expectedActionKeys).forEach((key) => {
+        expect(typeof (checkout as any)[key]).toBe('function');
+      });
+    });
+
+    // Mirrors the regression guard above for useCheckoutElements(), which
+    // returns the same Elements-shaped surface but with a type that makes
+    // the contract explicit for Elements consumers.
+    it('useCheckoutElements() exposes every action method returned by loadActions', async () => {
+      const testMockCheckoutActions = mocks.mockCheckoutActions();
+      mockCheckoutSdk.loadActions.mockResolvedValue({
+        type: 'success',
+        actions: testMockCheckoutActions,
+      });
+
+      const {result, waitForNextUpdate} = renderHook(
+        () => useCheckoutElements(),
+        {
+          wrapper,
+          initialProps: {stripe: mockStripe},
+        }
+      );
+
+      await waitForNextUpdate();
+
+      if (result.current.type !== 'success') {
+        throw new Error(
+          `expected success, got ${JSON.stringify(result.current)}`
+        );
+      }
+      const {checkout} = result.current;
+
+      const {
+        getSession: _getSession,
+        ...expectedActionKeys
+      } = testMockCheckoutActions;
+      Object.keys(expectedActionKeys).forEach((key) => {
+        expect(typeof (checkout as any)[key]).toBe('function');
+      });
+    });
+
+    // useCheckoutForm() under the wrong provider must fail loudly at first
+    // render instead of silently returning undefined-shaped actions. The
+    // error must name the expected provider so integrators can self-serve.
+    it('useCheckoutForm() throws when used under <CheckoutElementsProvider>', async () => {
+      consoleError.mockImplementation(() => {});
+      const testMockCheckoutActions = mocks.mockCheckoutActions();
+      mockCheckoutSdk.loadActions.mockResolvedValue({
+        type: 'success',
+        actions: testMockCheckoutActions,
+      });
+
+      const {result, waitForNextUpdate} = renderHook(() => useCheckoutForm(), {
+        wrapper,
+        initialProps: {stripe: mockStripe},
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.message).toMatch(
+        /useCheckoutForm\(\) must be used inside <CheckoutFormProvider>/
+      );
     });
   });
 

--- a/src/checkout/components/CheckoutElementsProvider.tsx
+++ b/src/checkout/components/CheckoutElementsProvider.tsx
@@ -80,6 +80,7 @@ export const CheckoutElementsProvider: FunctionComponent<PropsWithChildren<
               const {actions} = result;
               setState({
                 type: 'success',
+                sdkKind: 'elements',
                 sdk,
                 checkoutActions: actions,
                 session: actions.getSession(),
@@ -87,9 +88,13 @@ export const CheckoutElementsProvider: FunctionComponent<PropsWithChildren<
 
               sdk.on('change', (session: stripeJs.StripeCheckoutSession) => {
                 setState((prevState) => {
-                  if (prevState.type === 'success') {
+                  if (
+                    prevState.type === 'success' &&
+                    prevState.sdkKind === 'elements'
+                  ) {
                     return {
                       type: 'success',
+                      sdkKind: 'elements',
                       sdk: prevState.sdk,
                       checkoutActions: prevState.checkoutActions,
                       session,

--- a/src/checkout/components/CheckoutFormProvider.test.tsx
+++ b/src/checkout/components/CheckoutFormProvider.test.tsx
@@ -159,7 +159,7 @@ describe('CheckoutFormProvider', () => {
       });
     });
 
-    // Mirrors the pay-server runtime transform that strips 5 client-only
+    // Mirrors the runtime transform of stripe-js that strips 5 client-only
     // update methods before loadActions() resolves. Guards against React
     // wiring that would accidentally re-expose those methods via
     // useCheckout() under <CheckoutFormProvider>.

--- a/src/checkout/components/CheckoutFormProvider.test.tsx
+++ b/src/checkout/components/CheckoutFormProvider.test.tsx
@@ -3,7 +3,11 @@ import {render, act, waitFor} from '@testing-library/react';
 import {renderHook} from '@testing-library/react-hooks';
 
 import {CheckoutFormProvider} from './CheckoutFormProvider';
-import {useCheckout} from './CheckoutContext';
+import {
+  useCheckout,
+  useCheckoutElements,
+  useCheckoutForm,
+} from './CheckoutContext';
 import * as mocks from '../../../test/mocks';
 import makeDeferred from '../../../test/makeDeferred';
 
@@ -153,6 +157,147 @@ describe('CheckoutFormProvider', () => {
           ...testMockSession,
         },
       });
+    });
+
+    // Mirrors the pay-server runtime transform that strips 5 client-only
+    // update methods before loadActions() resolves. Guards against React
+    // wiring that would accidentally re-expose those methods via
+    // useCheckout() under <CheckoutFormProvider>.
+    it('does not expose the 5 stripped action methods on useCheckout().checkout', async () => {
+      const stripe: any = mocks.mockStripe();
+      const mockSdk = mocks.mockCheckoutSdk();
+      const {
+        updateEmail: _updateEmail,
+        updatePhoneNumber: _updatePhoneNumber,
+        updateShippingAddress: _updateShippingAddress,
+        updateBillingAddress: _updateBillingAddress,
+        updateTaxIdInfo: _updateTaxIdInfo,
+        ...formStrippedActions
+      } = mocks.mockCheckoutActions();
+
+      mockSdk.loadActions.mockResolvedValue({
+        type: 'success',
+        actions: formStrippedActions,
+      });
+      stripe.initCheckoutFormSdk.mockReturnValue(mockSdk);
+
+      const wrapper = ({children}: any) => (
+        <CheckoutFormProvider
+          stripe={stripe}
+          options={{clientSecret: fakeClientSecret}}
+        >
+          {children}
+        </CheckoutFormProvider>
+      );
+
+      const {result, waitForNextUpdate} = renderHook(() => useCheckout(), {
+        wrapper,
+      });
+
+      await waitForNextUpdate();
+
+      if (result.current.type !== 'success') {
+        throw new Error(
+          `expected success, got ${JSON.stringify(result.current)}`
+        );
+      }
+      const {checkout} = result.current;
+
+      expect((checkout as any).updateEmail).toBeUndefined();
+      expect((checkout as any).updatePhoneNumber).toBeUndefined();
+      expect((checkout as any).updateShippingAddress).toBeUndefined();
+      expect((checkout as any).updateBillingAddress).toBeUndefined();
+      expect((checkout as any).updateTaxIdInfo).toBeUndefined();
+
+      expect(typeof checkout.applyPromotionCode).toBe('function');
+      expect(typeof checkout.removePromotionCode).toBe('function');
+      expect(typeof checkout.updateLineItemQuantity).toBe('function');
+      expect(typeof checkout.updateShippingOption).toBe('function');
+      expect(typeof checkout.confirm).toBe('function');
+    });
+
+    // useCheckoutForm() is the recommended hook for Form consumers — it
+    // returns the narrower StripeCheckoutFormValue where the 5 stripped
+    // methods are omitted at the type level, so calls to them become
+    // TypeScript errors instead of runtime "is not a function" failures.
+    it('useCheckoutForm() returns the Form-narrowed action surface', async () => {
+      const stripe: any = mocks.mockStripe();
+      const mockSdk = mocks.mockCheckoutSdk();
+      const {
+        updateEmail: _updateEmail,
+        updatePhoneNumber: _updatePhoneNumber,
+        updateShippingAddress: _updateShippingAddress,
+        updateBillingAddress: _updateBillingAddress,
+        updateTaxIdInfo: _updateTaxIdInfo,
+        ...formStrippedActions
+      } = mocks.mockCheckoutActions();
+
+      mockSdk.loadActions.mockResolvedValue({
+        type: 'success',
+        actions: formStrippedActions,
+      });
+      stripe.initCheckoutFormSdk.mockReturnValue(mockSdk);
+
+      const wrapper = ({children}: any) => (
+        <CheckoutFormProvider
+          stripe={stripe}
+          options={{clientSecret: fakeClientSecret}}
+        >
+          {children}
+        </CheckoutFormProvider>
+      );
+
+      const {result, waitForNextUpdate} = renderHook(() => useCheckoutForm(), {
+        wrapper,
+      });
+
+      await waitForNextUpdate();
+
+      if (result.current.type !== 'success') {
+        throw new Error(
+          `expected success, got ${JSON.stringify(result.current)}`
+        );
+      }
+      const {checkout} = result.current;
+
+      expect((checkout as any).updateEmail).toBeUndefined();
+      expect((checkout as any).updatePhoneNumber).toBeUndefined();
+      expect((checkout as any).updateShippingAddress).toBeUndefined();
+      expect((checkout as any).updateBillingAddress).toBeUndefined();
+      expect((checkout as any).updateTaxIdInfo).toBeUndefined();
+
+      expect(typeof checkout.applyPromotionCode).toBe('function');
+      expect(typeof checkout.removePromotionCode).toBe('function');
+      expect(typeof checkout.updateLineItemQuantity).toBe('function');
+      expect(typeof checkout.updateShippingOption).toBe('function');
+      expect(typeof checkout.confirm).toBe('function');
+    });
+
+    // useCheckoutElements() under the wrong provider must fail loudly at
+    // first render so integrators catch the misuse immediately instead of
+    // calling methods that don't exist on the Form SDK at runtime.
+    it('useCheckoutElements() throws when used under <CheckoutFormProvider>', async () => {
+      consoleError.mockImplementation(() => {});
+      const wrapper = ({children}: any) => (
+        <CheckoutFormProvider
+          stripe={mockStripe}
+          options={{clientSecret: fakeClientSecret}}
+        >
+          {children}
+        </CheckoutFormProvider>
+      );
+
+      const {result, waitForNextUpdate} = renderHook(
+        () => useCheckoutElements(),
+        {wrapper}
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.message).toMatch(
+        /useCheckoutElements\(\) must be used inside <CheckoutElementsProvider>/
+      );
     });
   });
 

--- a/src/checkout/components/CheckoutFormProvider.tsx
+++ b/src/checkout/components/CheckoutFormProvider.tsx
@@ -73,6 +73,7 @@ export const CheckoutFormProvider: FunctionComponent<PropsWithChildren<
               const {actions} = result;
               setState({
                 type: 'success',
+                sdkKind: 'form',
                 sdk,
                 checkoutActions: actions,
                 session: actions.getSession(),
@@ -80,9 +81,13 @@ export const CheckoutFormProvider: FunctionComponent<PropsWithChildren<
 
               sdk.on('change', (session: stripeJs.StripeCheckoutSession) => {
                 setState((prevState) => {
-                  if (prevState.type === 'success') {
+                  if (
+                    prevState.type === 'success' &&
+                    prevState.sdkKind === 'form'
+                  ) {
                     return {
                       type: 'success',
+                      sdkKind: 'form',
                       sdk: prevState.sdk,
                       checkoutActions: prevState.checkoutActions,
                       session,

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -1,8 +1,14 @@
 export {CheckoutElementsProvider} from './components/CheckoutElementsProvider';
 export {
   useCheckout,
+  useCheckoutElements,
+  useCheckoutForm,
   StripeUseCheckoutResult,
+  StripeUseCheckoutElementsResult,
+  StripeUseCheckoutFormResult,
   StripeCheckoutValue,
+  StripeCheckoutElementsValue,
+  StripeCheckoutFormValue,
 } from './components/CheckoutContext';
 export {CheckoutFormProvider} from './components/CheckoutFormProvider';
 export * from './types';

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -47,8 +47,10 @@ export const mockCheckoutActions = () => {
     updatePhoneNumber: jest.fn(),
     updateEmail: jest.fn(),
     updateLineItemQuantity: jest.fn(),
+    updateTaxIdInfo: jest.fn(),
     updateShippingOption: jest.fn(),
     confirm: jest.fn(),
+    runServerUpdate: jest.fn(),
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,10 +2395,10 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
-"@stripe/stripe-js@^9.2.0":
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-9.2.0.tgz#2579b4c13ff2f1316c08e80b1bbec6dbb4d9b661"
-  integrity sha512-YSzLC0t6VS9MDdPTynSMqU8IxrItFUjkDORALFT6sSMR/XZ5Vgm3RDp/Gk7z727MC4A9s4MFVel0gF0c7+kdrg==
+"@stripe/stripe-js@^9.3.1":
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-9.3.1.tgz#2c71b9d62f2a74cd661f46e691a55a13340d5136"
+  integrity sha512-oWpAEENuVg8aw4W2OUAM9WxRDtIV2YTLr2nr6qHT+D8tHPW7bya61ufinPpUespyRNUVXqesnHo+jQdUNsGywA==
 
 "@testing-library/dom@^8.5.0":
   version "8.13.0"


### PR DESCRIPTION
### Summary & motivation

stripe-js v9.3.1 removed 5 action methods from `initCheckoutFormSdk()` (the Form SDK now exposes 7 actions instead of 12). This PR updates react-stripe-js to reflect that.

### What changed

- Added two new hooks:
  - `useCheckoutElements()` for use inside `<CheckoutElementsProvider>`. Returns the full 12-action surface.
  - `useCheckoutForm()` for use inside `<CheckoutFormProvider>`. Returns the narrower 7-action surface, so calling one of the removed methods is now a compile-time error.
  - Both throw a clear runtime error if used under the wrong provider.
- Deprecated `useCheckout()` via JSDoc. It still works and points users at the new hooks. It now aliases `useCheckoutElements()` so behavior is consistent.
- Bumped the `@stripe/stripe-js` peer dependency floor to `>=9.3.1 <10.0.0` since we now reference types introduced in 9.3.1.

### What does not change

- Existing `<CheckoutElementsProvider>` + `useCheckout()` integrations keep working exactly as they do today. No code changes required for Elements consumers.
### API review

<!-- Delete this section if this change involves no API changes. -->

Copy [this template] **or** link to an API review issue.

[this template]:
  https://github.com/stripe/react-stripe-js/tree/master/.github/API_REVIEW.md

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
