### PR TITLE
Add availablepaymentmethodschange functionality

### DIFF
--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -818,6 +818,32 @@ describe('createElementComponent', () => {
       expect(mockHandler).not.toHaveBeenCalled();
     });
 
+    it('propagates the Element`s availablepaymentmethodschange event to the current onAvailablePaymentMethodsChange prop for ExpressCheckoutElement', () => {
+      const mockHandler = jest.fn();
+      const mockHandler2 = jest.fn();
+      const {rerender} = render(
+        <Elements stripe={mockStripe}>
+          <ExpressCheckoutElement
+            onConfirm={() => {}}
+            onAvailablePaymentMethodsChange={mockHandler}
+          />
+        </Elements>
+      );
+      rerender(
+        <Elements stripe={mockStripe}>
+          <ExpressCheckoutElement
+            onConfirm={() => {}}
+            onAvailablePaymentMethodsChange={mockHandler2}
+          />
+        </Elements>
+      );
+
+      const eventMock = Symbol('availablepaymentmethodschange');
+      simulateEvent('availablepaymentmethodschange', eventMock);
+      expect(mockHandler2).toHaveBeenCalledWith(eventMock);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
     it('propagates the Element`s savedpaymentmethodremove event to the current onSavedPaymentMethodRemove prop', () => {
       const mockHandler = jest.fn();
       const mockHandler2 = jest.fn();
@@ -855,6 +881,26 @@ describe('createElementComponent', () => {
       const updateEventMock = Symbol('savedpaymentmethodupdate');
       simulateEvent('savedpaymentmethodupdate', updateEventMock);
       expect(mockHandler2).toHaveBeenCalledWith(updateEventMock);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    it('propagates the Element`s availablepaymentmethodschange event to the current onAvailablePaymentMethodsChange prop for PaymentElement', () => {
+      const mockHandler = jest.fn();
+      const mockHandler2 = jest.fn();
+      const {rerender} = render(
+        <Elements stripe={mockStripe}>
+          <PaymentElement onAvailablePaymentMethodsChange={mockHandler} />
+        </Elements>
+      );
+      rerender(
+        <Elements stripe={mockStripe}>
+          <PaymentElement onAvailablePaymentMethodsChange={mockHandler2} />
+        </Elements>
+      );
+
+      const eventMock = Symbol('availablepaymentmethodschange');
+      simulateEvent('availablepaymentmethodschange', eventMock);
+      expect(mockHandler2).toHaveBeenCalledWith(eventMock);
       expect(mockHandler).not.toHaveBeenCalled();
     });
 

--- a/src/components/createElementComponent.tsx
+++ b/src/components/createElementComponent.tsx
@@ -35,6 +35,7 @@ interface PrivateElementProps {
   onShippingRateChange?: UnknownCallback;
   onSavedPaymentMethodRemove?: UnknownCallback;
   onSavedPaymentMethodUpdate?: UnknownCallback;
+  onAvailablePaymentMethodsChange?: UnknownCallback;
   options?: UnknownOptions;
 }
 
@@ -66,6 +67,7 @@ const createElementComponent = (
     onShippingRateChange,
     onSavedPaymentMethodRemove,
     onSavedPaymentMethodUpdate,
+    onAvailablePaymentMethodsChange,
   }) => {
     const ctx = useElementsOrCheckoutContextWithUseCase(
       `mounts <${displayName}>`
@@ -105,6 +107,11 @@ const createElementComponent = (
       element,
       'savedpaymentmethodupdate',
       onSavedPaymentMethodUpdate
+    );
+    useAttachEvent(
+      element,
+      'availablepaymentmethodschange',
+      onAvailablePaymentMethodsChange
     );
     useAttachEvent(element, 'change', onChange);
 
@@ -257,6 +264,7 @@ const createElementComponent = (
     onShippingRateChange: PropTypes.func,
     onSavedPaymentMethodRemove: PropTypes.func,
     onSavedPaymentMethodUpdate: PropTypes.func,
+    onAvailablePaymentMethodsChange: PropTypes.func,
     options: PropTypes.object as any,
   };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -405,7 +405,9 @@ export interface PaymentElementProps extends ElementProps {
   /**
    * Triggered when the set of available payment methods changes.
    */
-  onAvailablePaymentMethodsChange?: (event: any) => any;
+  onAvailablePaymentMethodsChange?: (
+    event: stripeJs.StripePaymentElementAvailablePaymentMethodsChangeEvent
+  ) => any;
 }
 
 export type PaymentElementComponent = FunctionComponent<PaymentElementProps>;
@@ -467,7 +469,9 @@ export interface ExpressCheckoutElementProps extends ElementProps {
   /**
    * Triggered when the set of available payment methods changes.
    */
-  onAvailablePaymentMethodsChange?: (event: any) => any;
+  onAvailablePaymentMethodsChange?: (
+    event: stripeJs.StripeExpressCheckoutElementAvailablePaymentMethodsChangeEvent
+  ) => any;
 }
 
 export type ExpressCheckoutElementComponent = FunctionComponent<

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -401,6 +401,11 @@ export interface PaymentElementProps extends ElementProps {
     error?: string;
     payment_method: stripeJs.StripePaymentElementChangeEvent['value']['payment_method'];
   }) => any;
+
+  /**
+   * Triggered when the set of available payment methods changes.
+   */
+  onAvailablePaymentMethodsChange?: (event: any) => any;
 }
 
 export type PaymentElementComponent = FunctionComponent<PaymentElementProps>;
@@ -458,6 +463,11 @@ export interface ExpressCheckoutElementProps extends ElementProps {
   onShippingRateChange?: (
     event: stripeJs.StripeExpressCheckoutElementShippingRateChangeEvent
   ) => any;
+
+  /**
+   * Triggered when the set of available payment methods changes.
+   */
+  onAvailablePaymentMethodsChange?: (event: any) => any;
 }
 
 export type ExpressCheckoutElementComponent = FunctionComponent<


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->
Add ability for PE and ECE to use the new `availablepaymentmethodschange` event:
https://docs.stripe.com/js/elements_object/payment_element_availablepaymentmethodschange_event
https://docs.stripe.com/js/elements_object/express_checkout_element_availablepaymentmethodschange_event

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->
I wrote unit tests

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
