### PR TITLE
docs(readme): replace removed `ReactDOM.render` with `createRoot` for React 18/19

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install @stripe/react-stripe-js @stripe/stripe-js
 
 ```jsx
 import React, {useState} from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import {loadStripe} from '@stripe/stripe-js';
 import {
   PaymentElement,
@@ -126,14 +126,15 @@ const App = () => (
   </Elements>
 );
 
-ReactDOM.render(<App />, document.body);
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);
 ```
 
 #### Using class components
 
 ```jsx
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import {loadStripe} from '@stripe/stripe-js';
 import {
   PaymentElement,
@@ -223,7 +224,8 @@ const App = () => (
   </Elements>
 );
 
-ReactDOM.render(<App />, document.body);
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);
 ```
 
 ### TypeScript support


### PR DESCRIPTION
Fixes #677.

Both "Minimal example" snippets in `README.md` used `ReactDOM.render(<App />, document.body)`, which:
- is **removed in React 19** (throws `TypeError: ReactDOM.render is not a function`), and
- is **deprecated in React 18** (prints a console warning),

both of which are within the package's declared `peerDependencies` range (`react: ">=16.8.0 <20.0.0"`).

This PR updates both snippets to use `createRoot` from `react-dom/client`, matching the React 18+ docs and Stripe's own hosted docs at https://stripe.com/docs/stripe-js/react. Also switches the mount target from `document.body` to `document.getElementById('root')` (a dedicated root node), matching the standard React docs guidance.

```diff
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
...
-ReactDOM.render(<App />, document.body);
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);
```

(both occurrences — hooks example and class-components example).