### PR TITLE
Pass loadedStripe.current to registerWithStripeJs in EmbeddedCheckoutProvider

### DIFF
--- a/src/components/EmbeddedCheckoutProvider.test.tsx
+++ b/src/components/EmbeddedCheckoutProvider.test.tsx
@@ -52,6 +52,28 @@ describe('EmbeddedCheckoutProvider', () => {
     expect(result.current.embeddedCheckout).toBe(mockEmbeddedCheckout);
   });
 
+  it('registers react-stripe-js as a wrapper with the resolved Stripe instance', async () => {
+    const wrapper = ({children}: {children?: React.ReactNode}) => (
+      <EmbeddedCheckoutProvider stripe={mockStripe} options={fakeOptions}>
+        {children}
+      </EmbeddedCheckoutProvider>
+    );
+
+    renderHook(() => useEmbeddedCheckoutContext(), {wrapper});
+
+    await act(() => mockEmbeddedCheckoutPromise);
+
+    expect(mockStripe._registerWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({name: 'react-stripe-js'})
+    );
+    expect(mockStripe.registerAppInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'react-stripe-js',
+        url: 'https://stripe.com/docs/stripe-js/react',
+      })
+    );
+  });
+
   it('only creates elements once', async () => {
     const TestConsumerComponent = () => {
       const _ = useEmbeddedCheckoutContext();

--- a/src/components/EmbeddedCheckoutProvider.tsx
+++ b/src/components/EmbeddedCheckoutProvider.tsx
@@ -150,8 +150,8 @@ export const EmbeddedCheckoutProvider: FunctionComponent<PropsWithChildren<
 
   // Attach react-stripe-js version to stripe.js instance
   React.useEffect(() => {
-    registerWithStripeJs(loadedStripe);
-  }, [loadedStripe]);
+    registerWithStripeJs(loadedStripe.current);
+  }, [ctx.embeddedCheckout]);
 
   // Warn on changes to stripe prop.
   // The stripe prop value can only go from null to non-null once and

--- a/src/utils/registerWithStripeJs.ts
+++ b/src/utils/registerWithStripeJs.ts
@@ -1,11 +1,19 @@
-export const registerWithStripeJs = (stripe: any) => {
-  if (!stripe || !stripe._registerWrapper || !stripe.registerAppInfo) {
+import * as stripeJs from '@stripe/stripe-js';
+
+export const registerWithStripeJs = (stripe: stripeJs.Stripe | null) => {
+  const candidate = stripe as
+    | (stripeJs.Stripe & {
+        _registerWrapper?: (wrapper: {name: string; version: string}) => void;
+      })
+    | null;
+
+  if (!candidate || !candidate._registerWrapper || !candidate.registerAppInfo) {
     return;
   }
 
-  stripe._registerWrapper({name: 'react-stripe-js', version: _VERSION});
+  candidate._registerWrapper({name: 'react-stripe-js', version: _VERSION});
 
-  stripe.registerAppInfo({
+  candidate.registerAppInfo({
     name: 'react-stripe-js',
     version: _VERSION,
     url: 'https://stripe.com/docs/stripe-js/react',


### PR DESCRIPTION
The useEffect that registers react-stripe-js as a wrapper on the Stripe instance passed loadedStripe, which is a React.useRef holding the resolved Stripe value, instead of loadedStripe.current. registerWithStripeJs then checks stripe._registerWrapper, which is undefined on the ref object, so the function always early-returns and the wrapper registration never fires for embedded checkout flows. CheckoutProvider already calls this with the resolved Stripe value.

This change passes loadedStripe.current and uses ctx.embeddedCheckout as the dependency, so the registration runs once the embedded checkout instance has been created with a known-good Stripe ref. Added a unit test in EmbeddedCheckoutProvider.test.tsx that asserts _registerWrapper and registerAppInfo are called with the expected react-stripe-js identity.

Also tightened registerWithStripeJs from stripe: any to stripe: stripe-js.Stripe | null. The internal _registerWrapper is not part of the public Stripe.js surface, so it stays behind a typed cast rather than being declared on the public type.