### PR TITLE
Expose onCancel prop on Checkout ExpressCheckoutElement

### DIFF
--- a/src/checkout/types/index.ts
+++ b/src/checkout/types/index.ts
@@ -73,10 +73,7 @@ export type CheckoutFormComponent = FunctionComponent<CheckoutFormProps>;
 
 export type ExpressCheckoutElementProps = Omit<
   RootExpressCheckoutElementProps,
-  | 'options'
-  | 'onClick'
-  | 'onShippingAddressChange'
-  | 'onShippingRateChange'
+  'options' | 'onClick' | 'onShippingAddressChange' | 'onShippingRateChange'
 > & {options?: stripeJs.StripeCheckoutExpressCheckoutElementOptions};
 
 export type ExpressCheckoutElementComponent = FunctionComponent<

--- a/src/checkout/types/index.ts
+++ b/src/checkout/types/index.ts
@@ -75,7 +75,6 @@ export type ExpressCheckoutElementProps = Omit<
   RootExpressCheckoutElementProps,
   | 'options'
   | 'onClick'
-  | 'onCancel'
   | 'onShippingAddressChange'
   | 'onShippingRateChange'
 > & {options?: stripeJs.StripeCheckoutExpressCheckoutElementOptions};


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

The runtime wiring for `onCancel` already existed in `createElementComponent.tsx` via `useAttachEvent(element, 'cancel', onCancel)`. This change is purely a type-level fix — removing `onCancel` from the `Omit` so the prop is no longer blocked at the TypeScript level.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

Existing tests in `src/components/createElementComponent.test.tsx` cover the cancel event behavior for `ExpressCheckoutElement` and were confirmed passing with `yarn test`


<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
