### PR TITLE
Return event handler result from wrapper

### DIFF
--- a/src/components/createElementComponent.test.tsx
+++ b/src/components/createElementComponent.test.tsx
@@ -4,8 +4,10 @@ import {render, act, waitFor} from '@testing-library/react';
 import * as ElementsModule from './Elements';
 import * as CheckoutContextModule from '../checkout/components/CheckoutContext';
 import {CheckoutElementsProvider} from '../checkout/components/CheckoutElementsProvider';
+import {CheckoutFormProvider} from '../checkout/components/CheckoutFormProvider';
 import createElementComponent from './createElementComponent';
 import * as mocks from '../../test/mocks';
+import makeDeferred from '../../test/makeDeferred';
 import {
   CardElementComponent,
   PaymentElementComponent,
@@ -21,7 +23,7 @@ import {
 } from '../types';
 
 const {Elements} = ElementsModule;
-const {useCheckout} = CheckoutContextModule;
+const {useCheckout, useCheckoutForm} = CheckoutContextModule;
 
 describe('createElementComponent', () => {
   let mockStripe: any;
@@ -515,6 +517,65 @@ describe('createElementComponent', () => {
       simulateEvent('confirm', confirmEventMock);
       expect(mockHandler2).toHaveBeenCalledWith(confirmEventMock);
       expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    it('returns the Payment Form Element`s async confirm handler result', async () => {
+      const validation = makeDeferred<void>();
+      const mockActions = mocks.mockCheckoutActions();
+      mockActions.confirm.mockResolvedValue({type: 'success'});
+      mockCheckoutSdk.loadActions.mockResolvedValue({
+        type: 'success',
+        actions: mockActions,
+      });
+      mockStripe.initCheckoutFormSdk.mockReturnValue(mockCheckoutSdk);
+
+      const CheckoutFormWithAsyncConfirm = () => {
+        const checkoutState = useCheckoutForm();
+        const onConfirm = async (event: any) => {
+          if (checkoutState.type !== 'success') {
+            return undefined;
+          }
+
+          await validation.promise;
+          return checkoutState.checkout.confirm({formConfirmEvent: event});
+        };
+
+        return <CheckoutForm onConfirm={onConfirm} />;
+      };
+
+      render(
+        <CheckoutFormProvider
+          stripe={mockStripe}
+          options={{clientSecret: 'cs_123'}}
+        >
+          <CheckoutFormWithAsyncConfirm />
+        </CheckoutFormProvider>
+      );
+
+      await waitFor(() =>
+        expect(mockCheckoutSdk.on).toHaveBeenCalledWith(
+          'change',
+          expect.any(Function)
+        )
+      );
+
+      const confirmHandler = simulateOn.mock.calls.find(
+        ([event]: any[]) => event === 'confirm'
+      )?.[1];
+      expect(confirmHandler).toEqual(expect.any(Function));
+
+      const confirmEventMock = Symbol('confirm');
+      const handlerResult = confirmHandler(confirmEventMock);
+
+      expect(handlerResult).toHaveProperty('then', expect.any(Function));
+      expect(mockActions.confirm).not.toHaveBeenCalled();
+
+      await validation.resolve(undefined);
+      await handlerResult;
+
+      expect(mockActions.confirm).toHaveBeenCalledWith({
+        formConfirmEvent: confirmEventMock,
+      });
     });
 
     it('propagates the Payment Form Element`s cancel event to the current onCancel prop', () => {

--- a/src/utils/useAttachEvent.ts
+++ b/src/utils/useAttachEvent.ts
@@ -20,10 +20,11 @@ export const useAttachEvent = <A extends unknown[]>(
       return () => {};
     }
 
-    const decoratedCb = (...args: A): void => {
+    const decoratedCb = (...args: A) => {
       if (cbRef.current) {
-        cbRef.current(...args);
+        return cbRef.current(...args);
       }
+      return undefined;
     };
 
     (element as any).on(event, decoratedCb);


### PR DESCRIPTION
## Summary

  Fixes an async `CheckoutForm` confirm handling bug that can cause Stripe.js to reject valid confirmations with:

  > IntegrationError: The confirm method must be called within the confirm event emitted from the Checkout form.

  ## Context

Stripe.js keeps the Checkout form confirm event “open” until the merchant’s `onConfirm` handler finishes. Guacamole’s confirm handler awaits ECE billing-address validation before calling `checkout.confirm({formConfirmEvent})`.

  `@stripe/react-stripe-js` wrapped Element event callbacks in `useAttachEvent`, but the wrapper called the merchant callback without returning its result. That made async `onConfirm` handlers look synchronous to Stripe.js, so Stripe.js could clear its internal `isInConfirmEvent` flag before `checkout.confirm` resumed. The confirm call then failed even though it was logically part of the original confirm handler.

  ## Changes

  - Return the merchant callback result from `useAttachEvent`.
  - Add a regression test for an async `CheckoutForm` `onConfirm` that awaits before calling `checkout.confirm({formConfirmEvent})`.

  ## Validation

  - `yarn jest src/components/createElementComponent.test.tsx --runInBand --watchman=false --verbose`
  - `yarn typecheck`
  - `yarn eslint --max-warnings=0 src/components/createElementComponent.test.tsx src/utils/useAttachEvent.ts`
  - `yarn lint:prettier -- src/components/createElementComponent.test.tsx src/utils/useAttachEvent.ts`
  - `env npm_config_cache=/private/tmp/react-stripe-js-npm-cache yarn test`