### PR TITLE
Add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
     "type": "git",
     "url": "https://github.com/stripe/react-stripe-js.git"
   },
+  "homepage": "https://stripe.com/docs/stripe-js/react",
+  "bugs": {
+    "url": "https://github.com/stripe/react-stripe-js/issues"
+  },
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
## Summary
- add the package homepage metadata for the React Stripe.js docs
- add the bugs.url metadata pointing to the GitHub issue tracker

## Verification
- node -e exact package metadata assertion
- npm pack --dry-run --ignore-scripts
- git diff --check

Related metadata bounty: charles-openclaw/charles-microbounties#661