### PR TITLE
chore: add package bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "type": "git",
     "url": "https://github.com/stripe/react-stripe-js.git"
   },
+  "bugs": {
+    "url": "https://github.com/stripe/react-stripe-js/issues"
+  },
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
## Summary
- add the package `bugs.url` metadata pointing to the repository issue tracker

## Validation
- `node -e "const p=require('./package.json'); if(p.bugs.url!=='https://github.com/stripe/react-stripe-js/issues') process.exit(1); console.log(p.name, p.bugs.url)"`
- `git diff --check`