### PR TITLE
Close project to external pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to React Stripe.js
 
-Thanks for contributing to React Stripe.js!
+This project is maintained by Stripe and does not accept external pull requests.
+We welcome bug reports and feature requests as issues.
 
 ## Issues
 
@@ -16,26 +17,6 @@ your integration.
 
 If you've found a bug in React Stripe.js, please [let us know][issue]! You may
 also want to check out our [issue template][issue-template].
-
-## API review
-
-At Stripe, we scrutinize changes that affect the developer API more so than
-implementation changes. If your code change involves adding, removing, or
-modifying the surface area of the API, we ask that you go through an API review
-by following [this guide][api-review]. It's best to go through API review before
-implementing a feature. If you've already implemented a feature, address the
-[API review][api-review] considerations within your pull request.
-
-Going through an API review is not required, but it helps us to understand the
-problem you are trying to solve, and enables us to collaborate and solve it
-together.
-
-## Code review
-
-All pull requests will be reviewed by someone from Stripe before merging. At
-Stripe, we believe that code review is for explaining and having a discussion
-around code. For those new to code review, we strongly recommend [this
-video][code-review] on "code review culture."
 
 ## Developing
 
@@ -65,8 +46,6 @@ We use a number of automated checks:
 You might want to configure your editor to automatically run these checks. Not
 passing any of these checks will cause the CI build to fail.
 
-[code-review]: https://www.youtube.com/watch?v=PJjmw9TRB7s
-[api-review]: .github/API_REVIEW.md
 [stripe.js]: https://stripe.com/docs/stripe.js
 [elements]: https://stripe.com/elements
 [issue]: https://github.com/stripe/react-stripe-js/issues/new

--- a/README.md
+++ b/README.md
@@ -238,5 +238,6 @@ Typings in React Stripe.js follow the same
 
 ### Contributing
 
-If you would like to contribute to React Stripe.js, please make sure to read our
-[contributor guidelines](CONTRIBUTING.md).
+This project is maintained by Stripe and does not accept external pull requests.
+If you have feedback or ideas, please
+[open an issue](https://github.com/stripe/react-stripe-js/issues/new).


### PR DESCRIPTION
### Summary & motivation
We've made the decision to disable PRs from new contributors. If there's a change you'd like to see in the repo, please open an issue and we're happy to discuss.

### Testing & documentation
- Add PR disclaimer to readme and contributors guide
- Disable PRs from new contributors via a Github setting
