### PR TITLE
Bump stripe js peer floor 9.10.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,3 +19,21 @@ jobs:
     - run: yarn run test:unit
     - run: yarn run build
     - run: yarn run test:package-types
+  min-peer-deps:
+    # Pin @stripe/stripe-js to the peer floor and typecheck + build against it,
+    # to confirm using an absent type/API fails CI. You likely need to bump the
+    # stripe-js peer dependency if this test fails.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 24.x
+    - run: yarn install --frozen-lockfile
+    - name: Pin @stripe/stripe-js to declared peer floor
+      run: |
+        FLOOR=$(node -p "require('./package.json').peerDependencies['@stripe/stripe-js'].match(/>=\s*([0-9]+\.[0-9]+\.[0-9]+)/)[1]")
+        echo "Typechecking against @stripe/stripe-js@$FLOOR"
+        yarn add --dev --exact "@stripe/stripe-js@$FLOOR"
+    - run: yarn run typecheck
+    - run: yarn run build

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@types/react": "18.0.5"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": ">=9.5.0 <10.0.0",
+    "@stripe/stripe-js": ">=9.10.0 <10.0.0",
     "react": ">=16.8.0 <20.0.0",
     "react-dom": ">=16.8.0 <20.0.0"
   }


### PR DESCRIPTION
### Summary & motivation

The checkout Terms Element uses createTermsElement and the 'terms' StripeElementType, which only exist in @stripe/stripe-js types as of 9.10.0. Building `src/` against 9.9.0 fails to compile (createTermsElement, 'terms', and StripeTermsElement are all missing). #691 already bumped the devDependency to ^9.10.0 but left the peer range at >=9.5.0; this realigns the peer floor with the actual minimum supported version.

Fixes #700

Committed-By-Agent: claude

### Testing & documentation

Created a new test to confirm that the peer-dep floor also passes CI.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
